### PR TITLE
Refactor the Shape type and module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xla"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["laurent <laurent.mazare@gmail.com>"]
 edition = "2021"
 description = "Bindings for the XLA C++ library."

--- a/examples/basics.rs
+++ b/examples/basics.rs
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
         result.to_vec::<f32>(),
         result.get_first_element::<f32>()?,
     );
-    let param = xla_builder.parameter_with_shape(0, &xla::Shape::new::<f32>(vec![]), "p")?;
+    let param = xla_builder.parameter_with_shape(0, &xla::ArrayShape::new::<f32>(vec![]), "p")?;
     let sum = param.add_(&param)?;
     let sum = sum.sqrt()?.build()?;
     let result = client.compile(&sum)?;

--- a/examples/loop.rs
+++ b/examples/loop.rs
@@ -6,7 +6,7 @@ fn main() -> Result<()> {
     let client = xla::PjRtClient::cpu()?;
     loop {
         let builder = xla::XlaBuilder::new("test");
-        let x = builder.parameter(0, f32::PRIMITIVE_TYPE, &[2], "x")?;
+        let x = builder.parameter(0, f32::TY, &[2], "x")?;
         let sum = x.reduce_sum(&[], false)?.build()?.compile(&client)?;
         let input = xla::Literal::vec1(&[4.2f32, 1.337f32]);
         let result = sum.execute::<xla::Literal>(&[input])?;
@@ -16,7 +16,7 @@ fn main() -> Result<()> {
         assert_eq!(result.to_vec::<f32>()?, [4.2, 1.337]);
 
         let builder = xla::XlaBuilder::new("test");
-        let x = builder.parameter(0, f32::PRIMITIVE_TYPE, &[-2], "x")?;
+        let x = builder.parameter(0, f32::TY, &[-2], "x")?;
         let sum = x.reduce_sum(&[0], false)?.build()?.compile(&client)?;
         let input = xla::Literal::vec1(&[4.2f32, 1.337f32]);
         let result = sum.execute::<xla::Literal>(&[input])?;
@@ -25,10 +25,10 @@ fn main() -> Result<()> {
         drop(sum);
         assert_eq!(result.to_vec::<f32>()?, [5.5369997]);
         // Dimensions got reduced.
-        assert_eq!(result.shape()?.dimensions(), []);
+        assert_eq!(result.array_shape()?.dims(), []);
 
         let builder = xla::XlaBuilder::new("test");
-        let x = builder.parameter(0, f32::PRIMITIVE_TYPE, &[-2], "x")?;
+        let x = builder.parameter(0, f32::TY, &[-2], "x")?;
         let sum = x.reduce_sum(&[0], true)?.build()?.compile(&client)?;
         let input = xla::Literal::vec1(&[4.2f32, 1.337f32]);
         let result = sum.execute::<xla::Literal>(&[input])?;
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
         drop(sum);
         assert_eq!(result.to_vec::<f32>()?, [5.5369997]);
         // keep_dims = true in this case.
-        assert_eq!(result.shape()?.dimensions(), [1]);
+        assert_eq!(result.array_shape()?.dims(), [1]);
         println!("Done!");
     }
 }

--- a/examples/nanogpt/var_store.rs
+++ b/examples/nanogpt/var_store.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 
-use xla::{FromRawBytes, Literal, PrimitiveType};
+use xla::{ElementType, FromRawBytes, Literal};
 
 #[derive(Clone)]
 pub struct VarStore {
@@ -24,7 +24,7 @@ impl VarStore {
     pub fn take(
         &mut self,
         s: &str,
-        expected_type: PrimitiveType,
+        expected_type: ElementType,
         expected_dims: &[usize],
     ) -> Result<Literal> {
         let path = format!("{}.{s}", self.path.join("."));
@@ -33,9 +33,9 @@ impl VarStore {
             .borrow_mut()
             .remove(&path)
             .with_context(|| format!("cannot find {path} in VarStore"))?;
-        let shape = literal.shape()?;
-        let element_type = shape.element_type();
-        let dims = shape.dimensions();
+        let shape = literal.array_shape()?;
+        let element_type = shape.ty();
+        let dims = shape.dims();
         if element_type != expected_type {
             anyhow::bail!(
                 "unexpected element type for {}, got {:?} expected {:?}",

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,9 @@ pub enum Error {
     #[error("unexpected number of dimensions, expected: {expected}, got: {got} ({dims:?})")]
     UnexpectedNumberOfDims { expected: usize, got: usize, dims: Vec<i64> },
 
+    #[error("not an element type, got: {got:?}")]
+    NotAnElementType { got: crate::PrimitiveType },
+
     #[error("not an array, expected: {expected:?}, got: {got:?}")]
     NotAnArray { expected: Option<usize>, got: crate::Shape },
 
@@ -22,7 +25,7 @@ pub enum Error {
     UnexpectedNumberOfElemsInTuple { expected: usize, got: usize },
 
     #[error("element type mismatch, on-device: {on_device:?}, on-host: {on_host:?}")]
-    ElementTypeMismatch { on_device: crate::PrimitiveType, on_host: crate::PrimitiveType },
+    ElementTypeMismatch { on_device: crate::ElementType, on_host: crate::ElementType },
 
     #[error("unsupported element type for {op}: {ty:?}")]
     UnsupportedElementType { ty: crate::PrimitiveType, op: &'static str },
@@ -30,7 +33,7 @@ pub enum Error {
     #[error(
         "target buffer is too large, offset {offset}, shape {shape:?}, buffer_len: {buffer_len}"
     )]
-    TargetBufferIsTooLarge { offset: usize, shape: crate::Shape, buffer_len: usize },
+    TargetBufferIsTooLarge { offset: usize, shape: crate::ArrayShape, buffer_len: usize },
 
     #[error("binary buffer is too large, element count {element_count}, buffer_len: {buffer_len}")]
     BinaryBufferIsTooLarge { element_count: usize, buffer_len: usize },

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,9 @@ pub enum Error {
     #[error("unexpected number of dimensions, expected: {expected}, got: {got} ({dims:?})")]
     UnexpectedNumberOfDims { expected: usize, got: usize, dims: Vec<i64> },
 
+    #[error("not an array, expected: {expected:?}, got: {got:?}")]
+    NotAnArray { expected: Option<usize>, got: crate::Shape },
+
     #[error("unexpected number of tuple elements, expected: {expected}, got: {got}")]
     UnexpectedNumberOfElemsInTuple { expected: usize, got: usize },
 

--- a/src/npy.rs
+++ b/src/npy.rs
@@ -288,7 +288,7 @@ impl crate::Literal {
         f.write_all(&[1u8, 0u8])?;
         let shape = self.array_shape()?;
         let header =
-            Header { descr: shape.ty(), fortran_order: false, shape: shape.dimensions().to_vec() };
+            Header { descr: shape.ty(), fortran_order: false, shape: shape.dims().to_vec() };
         let mut header = header.to_string()?;
         let pad = 16 - (NPY_MAGIC_STRING.len() + 5 + header.len()) % 16;
         for _ in 0..pad % 16 {
@@ -299,9 +299,7 @@ impl crate::Literal {
         f.write_all(header.as_bytes())?;
         let numel = self.element_count();
         let element_type = self.element_type()?;
-        let elt_size_in_bytes = element_type.element_size_in_bytes().ok_or_else(|| {
-            Error::Npy(format!("unsupported element type for npy {element_type:?}"))
-        })?;
+        let elt_size_in_bytes = element_type.element_size_in_bytes();
         let mut content = vec![0u8; numel * elt_size_in_bytes];
         self.copy_raw_to(&mut content)?;
         f.write_all(&content)?;

--- a/src/npy.rs
+++ b/src/npy.rs
@@ -26,7 +26,7 @@
 //! # Load multiple values from a npz file.
 //! values = np.loadz("test.npz")
 //! ```
-use crate::{Error, Literal, PrimitiveType, Result};
+use crate::{ElementType, Error, Literal, Result};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Read, Write};
@@ -58,7 +58,7 @@ fn read_header<R: Read>(reader: &mut R) -> Result<String> {
 
 #[derive(Debug, PartialEq)]
 struct Header {
-    descr: PrimitiveType,
+    descr: ElementType,
     fortran_order: bool,
     shape: Vec<i64>,
 }
@@ -68,14 +68,14 @@ impl Header {
         let fortran_order = if self.fortran_order { "True" } else { "False" };
         let mut shape = self.shape.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(",");
         let descr = match self.descr {
-            PrimitiveType::F16 => "f2",
-            PrimitiveType::F32 => "f4",
-            PrimitiveType::F64 => "f8",
-            PrimitiveType::S32 => "i4",
-            PrimitiveType::S64 => "i8",
-            PrimitiveType::S16 => "i2",
-            PrimitiveType::S8 => "i1",
-            PrimitiveType::U8 => "u1",
+            ElementType::F16 => "f2",
+            ElementType::F32 => "f4",
+            ElementType::F64 => "f8",
+            ElementType::S32 => "i4",
+            ElementType::S64 => "i8",
+            ElementType::S16 => "i2",
+            ElementType::S8 => "i1",
+            ElementType::U8 => "u1",
             descr => return Err(Error::Npy(format!("unsupported kind {descr:?}"))),
         };
         if !shape.is_empty() {
@@ -146,17 +146,17 @@ impl Header {
                 //     int64, int32, int16, int8,
                 //     uint8, and bool.
                 match descr.trim_matches(|c: char| c == '=' || c == '<' || c == '|') {
-                    "e" | "f2" => PrimitiveType::F16,
-                    "f" | "f4" => PrimitiveType::F32,
-                    "d" | "f8" => PrimitiveType::F64,
-                    "i" | "i4" => PrimitiveType::S32,
-                    "q" | "i8" => PrimitiveType::S64,
-                    "h" | "i2" => PrimitiveType::S16,
-                    "b" | "i1" => PrimitiveType::S8,
-                    "B" | "u1" => PrimitiveType::U8,
-                    "?" | "b1" => PrimitiveType::Pred,
-                    "F" | "F4" => PrimitiveType::C64,
-                    "D" | "F8" => PrimitiveType::C128,
+                    "e" | "f2" => ElementType::F16,
+                    "f" | "f4" => ElementType::F32,
+                    "d" | "f8" => ElementType::F64,
+                    "i" | "i4" => ElementType::S32,
+                    "q" | "i8" => ElementType::S64,
+                    "h" | "i2" => ElementType::S16,
+                    "b" | "i1" => ElementType::S8,
+                    "B" | "u1" => ElementType::U8,
+                    "?" | "b1" => ElementType::Pred,
+                    "F" | "F4" => ElementType::C64,
+                    "D" | "F8" => ElementType::C128,
                     descr => return Err(Error::Npy(format!("unrecognized descr {descr}"))),
                 }
             }
@@ -183,7 +183,7 @@ pub trait FromRawBytes: Sized {
     type Context;
     fn from_raw_bytes(
         h: &Self::Context,
-        ty: PrimitiveType,
+        ty: ElementType,
         dims: &[usize],
         bytes: &[u8],
     ) -> Result<Self>;
@@ -261,7 +261,7 @@ impl FromRawBytes for crate::Literal {
 
     fn from_raw_bytes(
         _: &Self::Context,
-        ty: PrimitiveType,
+        ty: ElementType,
         dims: &[usize],
         bytes: &[u8],
     ) -> Result<Self> {
@@ -274,7 +274,7 @@ impl FromRawBytes for crate::PjRtBuffer {
 
     fn from_raw_bytes(
         client: &Self::Context,
-        ty: PrimitiveType,
+        ty: ElementType,
         dims: &[usize],
         bytes: &[u8],
     ) -> Result<Self> {
@@ -286,12 +286,9 @@ impl crate::Literal {
     fn write<T: Write>(&self, f: &mut T) -> Result<()> {
         f.write_all(NPY_MAGIC_STRING)?;
         f.write_all(&[1u8, 0u8])?;
-        let shape = self.shape()?;
-        let header = Header {
-            descr: shape.element_type(),
-            fortran_order: false,
-            shape: shape.dimensions().to_vec(),
-        };
+        let shape = self.array_shape()?;
+        let header =
+            Header { descr: shape.ty(), fortran_order: false, shape: shape.dimensions().to_vec() };
         let mut header = header.to_string()?;
         let pad = 16 - (NPY_MAGIC_STRING.len() + 5 + header.len()) % 16;
         for _ in 0..pad % 16 {
@@ -343,14 +340,14 @@ mod tests {
         let h = "{'descr': '<f8', 'fortran_order': False, 'shape': (128,), }";
         assert_eq!(
             Header::parse(h).unwrap(),
-            Header { descr: crate::PrimitiveType::F64, fortran_order: false, shape: vec![128] }
+            Header { descr: crate::ElementType::F64, fortran_order: false, shape: vec![128] }
         );
         let h = "{'descr': '<f4', 'fortran_order': True, 'shape': (256,1,128), }";
         let h = Header::parse(h).unwrap();
         assert_eq!(
             h,
             Header {
-                descr: crate::PrimitiveType::F32,
+                descr: crate::ElementType::F32,
                 fortran_order: true,
                 shape: vec![256, 1, 128]
             }
@@ -360,7 +357,7 @@ mod tests {
             "{'descr': '<f4', 'fortran_order': True, 'shape': (256,1,128,), }"
         );
 
-        let h = Header { descr: crate::PrimitiveType::S64, fortran_order: false, shape: vec![] };
+        let h = Header { descr: crate::ElementType::S64, fortran_order: false, shape: vec![] };
         assert_eq!(
             h.to_string().unwrap(),
             "{'descr': '<i8', 'fortran_order': False, 'shape': (), }"

--- a/src/wrappers/literal.rs
+++ b/src/wrappers/literal.rs
@@ -51,8 +51,9 @@ impl Literal {
     /// primitive type that the literal uses.
     pub fn get_first_element<T: NativeType + ArrayElement>(&self) -> Result<T> {
         let ty = self.ty()?;
-        if ty != T::PRIMITIVE_TYPE {
-            Err(Error::ElementTypeMismatch { on_device: ty, on_host: T::PRIMITIVE_TYPE })?
+        let on_host = T::TY.primitive_type();
+        if ty != on_host {
+            Err(Error::ElementTypeMismatch { on_device: ty, on_host })?
         }
         if self.element_count() == 0 {
             Err(Error::EmptyLiteral)?
@@ -111,8 +112,9 @@ impl Literal {
     pub fn copy_raw_to<T: ArrayElement>(&self, dst: &mut [T]) -> Result<()> {
         let ty = self.ty()?;
         let element_count = self.element_count();
-        if ty != T::PRIMITIVE_TYPE {
-            Err(Error::ElementTypeMismatch { on_device: ty, on_host: T::PRIMITIVE_TYPE })?
+        let on_host = T::TY.primitive_type();
+        if ty != on_host {
+            Err(Error::ElementTypeMismatch { on_device: ty, on_host })?
         }
         if dst.len() > element_count {
             Err(Error::BinaryBufferIsTooLarge { element_count, buffer_len: dst.len() })?
@@ -133,8 +135,9 @@ impl Literal {
     pub fn copy_raw_from<T: ArrayElement>(&mut self, src: &[T]) -> Result<()> {
         let ty = self.ty()?;
         let element_count = self.element_count();
-        if ty != T::PRIMITIVE_TYPE {
-            Err(Error::ElementTypeMismatch { on_device: ty, on_host: T::PRIMITIVE_TYPE })?
+        let on_host = T::TY.primitive_type();
+        if ty != on_host {
+            Err(Error::ElementTypeMismatch { on_device: ty, on_host })?
         }
         if src.len() > element_count {
             Err(Error::BinaryBufferIsTooLarge { element_count, buffer_len: src.len() })?

--- a/src/wrappers/mod.rs
+++ b/src/wrappers/mod.rs
@@ -17,7 +17,7 @@ pub use pjrt_buffer::PjRtBuffer;
 pub use pjrt_client::PjRtClient;
 pub use pjrt_device::PjRtDevice;
 pub use pjrt_loaded_executable::PjRtLoadedExecutable;
-pub use shape::Shape;
+pub use shape::{ArrayShape, Shape};
 pub use xla_builder::XlaBuilder;
 pub use xla_op::XlaOp;
 
@@ -98,8 +98,30 @@ pub enum ElementType {
     C128,
 }
 
+impl ElementType {
+    pub fn primitive_type(&self) -> PrimitiveType {
+        match self {
+            Self::Pred => PrimitiveType::Pred,
+            Self::S8 => PrimitiveType::S8,
+            Self::S16 => PrimitiveType::S16,
+            Self::S32 => PrimitiveType::S32,
+            Self::S64 => PrimitiveType::S64,
+            Self::U8 => PrimitiveType::U8,
+            Self::U16 => PrimitiveType::U16,
+            Self::U32 => PrimitiveType::U32,
+            Self::U64 => PrimitiveType::U64,
+            Self::F16 => PrimitiveType::F16,
+            Self::F32 => PrimitiveType::F32,
+            Self::Bf16 => PrimitiveType::Bf16,
+            Self::F64 => PrimitiveType::F64,
+            Self::C64 => PrimitiveType::C64,
+            Self::C128 => PrimitiveType::C128,
+        }
+    }
+}
+
 pub trait ArrayElement: Copy {
-    const PRIMITIVE_TYPE: PrimitiveType;
+    const TY: ElementType;
     const ELEMENT_SIZE_IN_BYTES: usize;
     const ZERO: Self;
 }
@@ -208,7 +230,7 @@ native_type!(
 macro_rules! element_type {
     ($ty:ty, $v:ident, $sz:tt) => {
         impl ArrayElement for $ty {
-            const PRIMITIVE_TYPE: PrimitiveType = PrimitiveType::$v;
+            const TY: ElementType = ElementType::$v;
             const ELEMENT_SIZE_IN_BYTES: usize = $sz;
             const ZERO: Self = 0 as Self;
         }
@@ -220,7 +242,7 @@ macro_rules! element_type {
 pub struct F16;
 
 impl ArrayElement for F16 {
-    const PRIMITIVE_TYPE: PrimitiveType = PrimitiveType::F16;
+    const TY: ElementType = ElementType::F16;
     const ELEMENT_SIZE_IN_BYTES: usize = 2;
     const ZERO: Self = Self;
 }
@@ -230,7 +252,7 @@ impl ArrayElement for F16 {
 pub struct Bf16;
 
 impl ArrayElement for Bf16 {
-    const PRIMITIVE_TYPE: PrimitiveType = PrimitiveType::Bf16;
+    const TY: ElementType = ElementType::Bf16;
     const ELEMENT_SIZE_IN_BYTES: usize = 2;
     const ZERO: Self = Self;
 }

--- a/src/wrappers/mod.rs
+++ b/src/wrappers/mod.rs
@@ -53,28 +53,26 @@ pub enum PrimitiveType {
 }
 
 impl PrimitiveType {
-    /// The size for this element type in bytes if defined.
-    pub fn element_size_in_bytes(&self) -> Option<usize> {
+    fn element_type(self) -> Result<ElementType> {
         match self {
-            PrimitiveType::Invalid => None,
-            PrimitiveType::Pred => None,
-            PrimitiveType::S8 => Some(1),
-            PrimitiveType::S16 => Some(2),
-            PrimitiveType::S32 => Some(4),
-            PrimitiveType::S64 => Some(8),
-            PrimitiveType::U8 => Some(1),
-            PrimitiveType::U16 => Some(2),
-            PrimitiveType::U32 => Some(4),
-            PrimitiveType::U64 => Some(8),
-            PrimitiveType::F16 => Some(2),
-            PrimitiveType::F32 => Some(4),
-            PrimitiveType::Bf16 => Some(2),
-            PrimitiveType::F64 => Some(8),
-            PrimitiveType::C64 => Some(8),
-            PrimitiveType::C128 => Some(16),
-            PrimitiveType::Tuple => None,
-            PrimitiveType::OpaqueType => None,
-            PrimitiveType::Token => None,
+            Self::Pred => Ok(ElementType::Pred),
+            Self::S8 => Ok(ElementType::S8),
+            Self::S16 => Ok(ElementType::S16),
+            Self::S32 => Ok(ElementType::S32),
+            Self::S64 => Ok(ElementType::S64),
+            Self::U8 => Ok(ElementType::U8),
+            Self::U16 => Ok(ElementType::U16),
+            Self::U32 => Ok(ElementType::U32),
+            Self::U64 => Ok(ElementType::U64),
+            Self::F16 => Ok(ElementType::F16),
+            Self::F32 => Ok(ElementType::F32),
+            Self::Bf16 => Ok(ElementType::Bf16),
+            Self::F64 => Ok(ElementType::F64),
+            Self::C64 => Ok(ElementType::C64),
+            Self::C128 => Ok(ElementType::C128),
+            Self::Invalid | Self::Tuple | Self::OpaqueType | Self::Token => {
+                Err(Error::NotAnElementType { got: self })
+            }
         }
     }
 }
@@ -99,6 +97,27 @@ pub enum ElementType {
 }
 
 impl ElementType {
+    /// The size for this element type in bytes.
+    pub fn element_size_in_bytes(&self) -> usize {
+        match self {
+            Self::Pred => 1,
+            Self::S8 => 1,
+            Self::S16 => 2,
+            Self::S32 => 4,
+            Self::S64 => 8,
+            Self::U8 => 1,
+            Self::U16 => 2,
+            Self::U32 => 4,
+            Self::U64 => 8,
+            Self::F16 => 2,
+            Self::F32 => 4,
+            Self::Bf16 => 2,
+            Self::F64 => 8,
+            Self::C64 => 8,
+            Self::C128 => 16,
+        }
+    }
+
     pub fn primitive_type(&self) -> PrimitiveType {
         match self {
             Self::Pred => PrimitiveType::Pred,

--- a/src/wrappers/pjrt_buffer.rs
+++ b/src/wrappers/pjrt_buffer.rs
@@ -53,8 +53,8 @@ impl PjRtBuffer {
         offset: usize,
     ) -> Result<()> {
         let shape = ArrayShape::try_from(&self.on_device_shape()?)?;
-        let on_host = T::TY.primitive_type();
-        let on_device = shape.primitive_type();
+        let on_host = T::TY;
+        let on_device = shape.primitive_type().element_type()?;
         if on_device != on_host {
             Err(Error::ElementTypeMismatch { on_device, on_host })?
         }

--- a/src/wrappers/pjrt_buffer.rs
+++ b/src/wrappers/pjrt_buffer.rs
@@ -1,5 +1,5 @@
 //! A view on a memory slice hosted on a device.
-use super::{ArrayElement, ArrayShape, FromPrimitive, Literal, PjRtDevice, Shape};
+use super::{ArrayElement, ArrayShape, Literal, PjRtDevice, Shape};
 use crate::{c_lib, Error, Result};
 
 /// A buffer represents a view on a memory slice hosted on a device.
@@ -34,16 +34,7 @@ impl PjRtBuffer {
     /// Retrieve the shape used by this buffer.
     pub fn on_device_shape(&self) -> Result<Shape> {
         let shape = unsafe { c_lib::pjrt_buffer_on_device_shape(self.buffer) };
-        let rank = unsafe { c_lib::shape_dimensions_size(shape) };
-        let dimensions: Vec<_> =
-            (0..rank).map(|i| unsafe { c_lib::shape_dimensions(shape, i) }).collect();
-        let ty = unsafe { c_lib::shape_element_type(shape) };
-        let tuple_shapes_size = unsafe { c_lib::shape_tuple_shapes_size(shape) };
-        unsafe { c_lib::shape_free(shape) };
-        match FromPrimitive::from_i32(ty) {
-            None => Err(Error::UnexpectedElementType(ty)),
-            Some(ty) => Ok(Shape { ty, dimensions, tuple_shapes_size }),
-        }
+        unsafe { Shape::from_ptr(shape) }
     }
 
     /// Copy the data stored in a buffer to host memory in a blocking way.

--- a/src/wrappers/pjrt_client.rs
+++ b/src/wrappers/pjrt_client.rs
@@ -117,7 +117,7 @@ impl PjRtClient {
                 self.ptr(),
                 device,
                 data.as_ptr() as *const libc::c_void,
-                T::PRIMITIVE_TYPE as i32,
+                T::TY.primitive_type() as i32,
                 dims.len() as i32,
                 dims.as_ptr(),
                 &mut buffer,

--- a/src/wrappers/pjrt_client.rs
+++ b/src/wrappers/pjrt_client.rs
@@ -134,16 +134,14 @@ impl PjRtClient {
     /// is returned.
     pub fn buffer_from_host_raw_bytes(
         &self,
-        ty: super::PrimitiveType,
+        ty: super::ElementType,
         data: &[u8],
         dims: &[usize],
         device: Option<&PjRtDevice>,
     ) -> Result<PjRtBuffer> {
         let mut buffer: c_lib::pjrt_buffer = std::ptr::null_mut();
         let element_count: usize = dims.iter().product();
-        let element_size_in_bytes = ty
-            .element_size_in_bytes()
-            .ok_or(Error::UnsupportedElementType { ty, op: "buffer_from_bytes" })?;
+        let element_size_in_bytes = ty.element_size_in_bytes();
         if element_count * element_size_in_bytes != data.len() {
             Err(Error::WrongElementCount { dims: dims.to_vec(), element_count })?
         }

--- a/src/wrappers/xla_builder.rs
+++ b/src/wrappers/xla_builder.rs
@@ -1,5 +1,6 @@
 use super::{
-    handle_status, FromPrimitive, Literal, NativeType, PrimitiveType, Shape, XlaComputation, XlaOp,
+    handle_status, ArrayShape, FromPrimitive, Literal, NativeType, PrimitiveType, Shape,
+    XlaComputation, XlaOp,
 };
 use crate::{c_lib, Error, Result};
 use std::rc::Rc;
@@ -107,10 +108,11 @@ impl XlaBuilder {
     pub fn parameter_with_shape(
         &self,
         parameter_number: i64,
-        shape: &Shape,
+        shape: &ArrayShape,
         name: &str,
     ) -> Result<XlaOp> {
-        self.parameter(parameter_number, shape.ty, &shape.dimensions, name)
+        let dims = shape.dims();
+        self.parameter(parameter_number, shape.primitive_type(), dims, name)
     }
 
     pub fn constant_r1c<T: NativeType>(&self, f: T, len: usize) -> Result<XlaOp> {

--- a/src/wrappers/xla_builder.rs
+++ b/src/wrappers/xla_builder.rs
@@ -78,7 +78,7 @@ impl XlaBuilder {
     pub fn parameter(
         &self,
         parameter_number: i64,
-        ty: PrimitiveType,
+        ty: super::ElementType,
         dims: &[i64],
         name: &str,
     ) -> Result<XlaOp> {
@@ -87,7 +87,7 @@ impl XlaBuilder {
             c_lib::parameter(
                 self.ptr(),
                 parameter_number,
-                ty as i32,
+                ty.primitive_type() as i32,
                 dims.len() as i32,
                 dims.as_ptr(),
                 name.as_ptr(),
@@ -112,7 +112,7 @@ impl XlaBuilder {
         name: &str,
     ) -> Result<XlaOp> {
         let dims = shape.dims();
-        self.parameter(parameter_number, shape.primitive_type(), dims, name)
+        self.parameter(parameter_number, shape.ty(), dims, name)
     }
 
     pub fn constant_r1c<T: NativeType>(&self, f: T, len: usize) -> Result<XlaOp> {
@@ -132,46 +132,47 @@ impl XlaBuilder {
     }
 
     /// A scalar node with the zero value for the associated type.
-    pub fn zero(&self, ty: super::PrimitiveType) -> Result<XlaOp> {
-        let op = unsafe { c_lib::op_zero(self.ptr(), ty as i32) };
+    pub fn zero(&self, ty: super::ElementType) -> Result<XlaOp> {
+        let op = unsafe { c_lib::op_zero(self.ptr(), ty.primitive_type() as i32) };
         self.wrap(op)
     }
 
     /// A scalar node with the one value for the associated type.
-    pub fn one(&self, ty: super::PrimitiveType) -> Result<XlaOp> {
-        let op = unsafe { c_lib::op_one(self.ptr(), ty as i32) };
+    pub fn one(&self, ty: super::ElementType) -> Result<XlaOp> {
+        let op = unsafe { c_lib::op_one(self.ptr(), ty.primitive_type() as i32) };
         self.wrap(op)
     }
 
     /// A scalar node with the minimum value for the associated type.
-    pub fn min_value(&self, ty: super::PrimitiveType) -> Result<XlaOp> {
-        let op = unsafe { c_lib::op_min_value(self.ptr(), ty as i32) };
+    pub fn min_value(&self, ty: super::ElementType) -> Result<XlaOp> {
+        let op = unsafe { c_lib::op_min_value(self.ptr(), ty.primitive_type() as i32) };
         self.wrap(op)
     }
 
     /// A scalar node with the maximum value for the associated type.
-    pub fn max_value(&self, ty: super::PrimitiveType) -> Result<XlaOp> {
-        let op = unsafe { c_lib::op_max_value(self.ptr(), ty as i32) };
+    pub fn max_value(&self, ty: super::ElementType) -> Result<XlaOp> {
+        let op = unsafe { c_lib::op_max_value(self.ptr(), ty.primitive_type() as i32) };
         self.wrap(op)
     }
 
     /// A constant node with the specified shape that holds increasing values starting from 0 along
     /// the iota dimension.
-    pub fn iota(
-        &self,
-        ty: super::PrimitiveType,
-        dims: &[i64],
-        iota_dimension: i64,
-    ) -> Result<XlaOp> {
+    pub fn iota(&self, ty: super::ElementType, dims: &[i64], iota_dimension: i64) -> Result<XlaOp> {
         let op = unsafe {
-            c_lib::op_iota(self.ptr(), ty as i32, dims.len(), dims.as_ptr(), iota_dimension)
+            c_lib::op_iota(
+                self.ptr(),
+                ty.primitive_type() as i32,
+                dims.len(),
+                dims.as_ptr(),
+                iota_dimension,
+            )
         };
         self.wrap(op)
     }
 
     /// A constant node for a unidimensional array of increasing values starting from 0.
-    pub fn iota1(&self, ty: super::PrimitiveType, size: usize) -> Result<XlaOp> {
-        let op = unsafe { c_lib::op_iota1(self.ptr(), ty as i32, size) };
+    pub fn iota1(&self, ty: super::ElementType, size: usize) -> Result<XlaOp> {
+        let op = unsafe { c_lib::op_iota1(self.ptr(), ty.primitive_type() as i32, size) };
         self.wrap(op)
     }
 
@@ -210,16 +211,7 @@ impl XlaBuilder {
         let mut out: c_lib::shape = std::ptr::null_mut();
         let status = unsafe { c_lib::get_shape(self.ptr(), op.op, &mut out) };
         handle_status(status)?;
-        let rank = unsafe { c_lib::shape_dimensions_size(out) };
-        let dimensions: Vec<_> =
-            (0..rank).map(|i| unsafe { c_lib::shape_dimensions(out, i) }).collect();
-        let ty = unsafe { c_lib::shape_element_type(out) };
-        let tuple_shapes_size = unsafe { c_lib::shape_tuple_shapes_size(out) };
-        unsafe { c_lib::shape_free(out) };
-        match FromPrimitive::from_i32(ty) {
-            None => Err(Error::UnexpectedElementType(ty)),
-            Some(ty) => Ok(Shape { ty, dimensions, tuple_shapes_size }),
-        }
+        unsafe { Shape::from_ptr(out) }
     }
 
     /// The dimension sizes associated with this op.
@@ -232,7 +224,7 @@ impl XlaBuilder {
     }
 
     /// The element type associated with this op.
-    pub fn get_element_type(&self, op: &XlaOp) -> Result<super::PrimitiveType> {
+    pub fn get_primitive_type(&self, op: &XlaOp) -> Result<super::PrimitiveType> {
         let mut ty = 0i32;
         let status = unsafe { c_lib::get_element_type(self.ptr(), op.op, &mut ty) };
         handle_status(status)?;

--- a/src/wrappers/xla_op.rs
+++ b/src/wrappers/xla_op.rs
@@ -269,13 +269,14 @@ impl XlaOp {
 
     /// A node that when executed generates values using a random uniform distribution.
     pub fn rng_uniform(min: &Self, max: &Self, shape: &ArrayShape) -> Result<Self> {
+        let dims = shape.dims();
         let op = unsafe {
             c_lib::op_rng_uniform(
                 min.op,
                 max.op,
-                shape.ty as i32,
-                shape.dimensions.len() as i32,
-                shape.dimensions.as_ptr(),
+                shape.primitive_type() as i32,
+                dims.len() as i32,
+                dims.as_ptr(),
             )
         };
         min.wrap(op)
@@ -283,13 +284,14 @@ impl XlaOp {
 
     /// A node that when executed generates values using a random normal distribution.
     pub fn rng_normal(mu: &Self, sigma: &Self, shape: &ArrayShape) -> Result<Self> {
+        let dims = shape.dims();
         let op = unsafe {
             c_lib::op_rng_normal(
                 mu.op,
                 sigma.op,
-                shape.ty as i32,
-                shape.dimensions.len() as i32,
-                shape.dimensions.as_ptr(),
+                shape.primitive_type() as i32,
+                dims.len() as i32,
+                dims.as_ptr(),
             )
         };
         mu.wrap(op)

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -12,7 +12,7 @@ fn add_op() -> Result<()> {
     let result = result.execute::<xla::Literal>(&[])?;
     let result = result[0][0].to_literal_sync()?;
     assert_eq!(result.element_count(), 2);
-    assert_eq!(result.shape()?, xla::Shape::new::<f32>(vec![2]));
+    assert_eq!(result.array_shape()?, xla::ArrayShape::new::<f32>(vec![2]));
     assert_eq!(result.get_first_element::<f32>()?, 85.);
     assert_eq!(result.to_vec::<f32>()?, [85., 85.]);
     Ok(())
@@ -22,7 +22,7 @@ fn add_op() -> Result<()> {
 fn sum_op() -> Result<()> {
     let client = xla::PjRtClient::cpu()?;
     let builder = xla::XlaBuilder::new("test");
-    let x = builder.parameter(0, f32::PRIMITIVE_TYPE, &[2], "x")?;
+    let x = builder.parameter(0, f32::TY, &[2], "x")?;
     let sum = x.reduce_sum(&[], false)?.build()?.compile(&client)?;
     let input = xla::Literal::vec1(&[4.2f32, 1.337f32]);
     let result = sum.execute::<xla::Literal>(&[input])?;
@@ -30,24 +30,24 @@ fn sum_op() -> Result<()> {
     assert_eq!(result.to_vec::<f32>()?, [4.2, 1.337]);
 
     let builder = xla::XlaBuilder::new("test");
-    let x = builder.parameter(0, f32::PRIMITIVE_TYPE, &[-2], "x")?;
+    let x = builder.parameter(0, f32::TY, &[-2], "x")?;
     let sum = x.reduce_sum(&[0], false)?.build()?.compile(&client)?;
     let input = xla::Literal::vec1(&[4.2f32, 1.337f32]);
     let result = sum.execute::<xla::Literal>(&[input])?;
     let result = result[0][0].to_literal_sync()?;
     assert_eq!(result.to_vec::<f32>()?, [5.5369997]);
     // Dimensions got reduced.
-    assert_eq!(result.shape()?.dimensions(), []);
+    assert_eq!(result.array_shape()?.dims(), []);
 
     let builder = xla::XlaBuilder::new("test");
-    let x = builder.parameter(0, f32::PRIMITIVE_TYPE, &[-2], "x")?;
+    let x = builder.parameter(0, f32::TY, &[-2], "x")?;
     let sum = x.reduce_sum(&[0], true)?.build()?.compile(&client)?;
     let input = xla::Literal::vec1(&[4.2f32, 1.337f32]);
     let result = sum.execute::<xla::Literal>(&[input])?;
     let result = result[0][0].to_literal_sync()?;
     assert_eq!(result.to_vec::<f32>()?, [5.5369997]);
     // keep_dims = true in this case.
-    assert_eq!(result.shape()?.dimensions(), [1]);
+    assert_eq!(result.array_shape()?.dims(), [1]);
     Ok(())
 }
 
@@ -55,14 +55,14 @@ fn sum_op() -> Result<()> {
 fn mean_op() -> Result<()> {
     let client = xla::PjRtClient::cpu()?;
     let builder = xla::XlaBuilder::new("test");
-    let x = builder.parameter(0, f32::PRIMITIVE_TYPE, &[-2], "x")?;
+    let x = builder.parameter(0, f32::TY, &[-2], "x")?;
     let sum = x.reduce_mean(&[0], false)?.build()?.compile(&client)?;
     let input = xla::Literal::vec1(&[4.2f32, 1.337f32]);
     let result = sum.execute::<xla::Literal>(&[input])?;
     let result = result[0][0].to_literal_sync()?;
     assert_eq!(result.to_vec::<f32>()?, [2.7684999]);
     // Dimensions got reduced.
-    assert_eq!(result.shape()?.dimensions(), []);
+    assert_eq!(result.array_shape()?.dims(), []);
     Ok(())
 }
 
@@ -70,8 +70,8 @@ fn mean_op() -> Result<()> {
 fn tuple_op() -> Result<()> {
     let client = xla::PjRtClient::cpu()?;
     let builder = xla::XlaBuilder::new("test");
-    let x = builder.parameter(0, f32::PRIMITIVE_TYPE, &[-1], "x")?;
-    let y = builder.parameter(1, f32::PRIMITIVE_TYPE, &[2], "x")?;
+    let x = builder.parameter(0, f32::TY, &[-1], "x")?;
+    let y = builder.parameter(1, f32::TY, &[2], "x")?;
     let tuple = builder.tuple(&[x, y])?.build()?.compile(&client)?;
     let x = xla::Literal::scalar(3.1f32);
     let y = xla::Literal::vec1(&[4.2f32, 1.337f32]);

--- a/tests/control_flow_tests.rs
+++ b/tests/control_flow_tests.rs
@@ -6,12 +6,12 @@ fn while_op() -> Result<()> {
     let builder = xla::XlaBuilder::new("test");
     let cond = {
         let builder = xla::XlaBuilder::new("cond");
-        let x = builder.parameter(0, i32::PRIMITIVE_TYPE, &[], "x")?;
+        let x = builder.parameter(0, i32::TY, &[], "x")?;
         x.le(&builder.constant_r0(10i32)?)?.build()?
     };
     let body = {
         let builder = xla::XlaBuilder::new("cond");
-        let x = builder.parameter(0, i32::PRIMITIVE_TYPE, &[], "x")?;
+        let x = builder.parameter(0, i32::TY, &[], "x")?;
         (x + builder.constant_r0(1i32)?)?.build()?
     };
     let init = builder.constant_r0(0i32)?;
@@ -21,7 +21,7 @@ fn while_op() -> Result<()> {
     let result = result.execute::<xla::Literal>(&[])?;
     let result = result[0][0].to_literal_sync()?;
     assert_eq!(result.element_count(), 1);
-    assert_eq!(result.shape()?, xla::Shape::new::<i32>(vec![]));
+    assert_eq!(result.shape()?, xla::Shape::array::<i32>(vec![]));
     assert_eq!(result.to_vec::<i32>()?, [11]);
     Ok(())
 }

--- a/tests/tuple_tests.rs
+++ b/tests/tuple_tests.rs
@@ -10,12 +10,12 @@ fn tuple_op() -> Result<()> {
     let result = client.compile(&computation)?;
     let result = result.execute::<xla::Literal>(&[])?;
     let mut result = result[0][0].to_literal_sync()?;
-    assert_eq!(result.shape()?, xla::Shape::tuple(2));
+    assert_eq!(result.shape()?.tuple_size(), Some(2));
     let as_tuple = result.decompose_tuple()?;
-    assert_eq!(result.shape()?, xla::Shape::tuple(0));
+    assert_eq!(result.shape()?.tuple_size(), Some(0));
     assert_eq!(as_tuple.len(), 2);
-    assert_eq!(as_tuple[0].shape()?, xla::Shape::new::<f32>(vec![]));
-    assert_eq!(as_tuple[1].shape()?, xla::Shape::new::<f32>(vec![2]));
+    assert_eq!(as_tuple[0].array_shape()?, xla::ArrayShape::new::<f32>(vec![]));
+    assert_eq!(as_tuple[1].array_shape()?, xla::ArrayShape::new::<f32>(vec![2]));
     assert_eq!(as_tuple[1].to_vec::<f32>()?, vec![43f32, 43f32]);
     Ok(())
 }

--- a/xla_rs/xla_rs.cc
+++ b/xla_rs/xla_rs.cc
@@ -799,6 +799,10 @@ void xla_op_free(xla_op o) { delete o; }
 
 size_t shape_tuple_shapes_size(const shape s) { return s->tuple_shapes_size(); }
 
+shape shape_tuple_shapes(const shape s, int i) {
+  return (shape)&s->tuple_shapes(i);
+}
+
 int shape_dimensions_size(const shape s) { return s->dimensions_size(); }
 
 int shape_element_type(const shape s) { return s->element_type(); }

--- a/xla_rs/xla_rs.h
+++ b/xla_rs/xla_rs.h
@@ -184,6 +184,7 @@ void xla_op_free(xla_op);
 
 int shape_dimensions_size(const shape);
 size_t shape_tuple_shapes_size(const shape);
+shape shape_tuple_shapes(const shape, int);
 int shape_element_type(const shape);
 int64_t shape_dimensions(const shape, int);
 void shape_free(shape);


### PR DESCRIPTION
Introduce a separate `ArrayShape` type and represent tuples in a more idiomatic way.