### PR TITLE
Add xla-moshi crate with the Mimi audio codec (AudioToAudio)

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -20,6 +20,7 @@ jobs:
       - run: |
           wget -nv https://github.com/elixir-nx/xla/releases/download/v0.10.0/xla_extension-0.10.0-x86_64-linux-gnu-cpu.tar.gz
           tar -xzvf xla_extension-0.10.0-x86_64-linux-gnu-cpu.tar.gz
+          echo "XLA_EXTENSION_DIR=$(pwd)/xla_extension" >> "$GITHUB_ENV"
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -41,6 +42,7 @@ jobs:
       - run: |
           wget -nv https://github.com/elixir-nx/xla/releases/download/v0.10.0/xla_extension-0.10.0-x86_64-linux-gnu-cpu.tar.gz
           tar -xzvf xla_extension-0.10.0-x86_64-linux-gnu-cpu.tar.gz
+          echo "XLA_EXTENSION_DIR=$(pwd)/xla_extension" >> "$GITHUB_ENV"
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -75,6 +77,7 @@ jobs:
       - run: |
           wget -nv https://github.com/elixir-nx/xla/releases/download/v0.10.0/xla_extension-0.10.0-x86_64-linux-gnu-cpu.tar.gz
           tar -xzvf xla_extension-0.10.0-x86_64-linux-gnu-cpu.tar.gz
+          echo "XLA_EXTENSION_DIR=$(pwd)/xla_extension" >> "$GITHUB_ENV"
       - uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "audiopus_sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62314a1546a2064e033665d658e88c620a62904be945f8147e6b16c3db9f8651"
+dependencies = [
+ "cmake",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,7 +215,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -232,6 +243,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -937,6 +954,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,7 +1218,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.19",
  "tracing",
 ]
 
@@ -1264,7 +1287,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-retry",
- "tokio-util",
+ "tokio-util 0.7.19",
  "tracing",
  "url",
  "wasm-bindgen-futures",
@@ -1285,7 +1308,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.19",
  "tokio_with_wasm",
  "tracing",
  "uuid",
@@ -1691,6 +1714,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "kaudio"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa91d027e02814ae876667542dd1b7cf91cb12f511ef29ea00022d7463699e"
+dependencies = [
+ "byteorder",
+ "futures-util",
+ "ogg",
+ "opus",
+ "regex",
+ "rubato",
+ "serde",
+ "serde_json",
+ "symphonia",
+ "thiserror 2.0.19",
+ "tokio",
+]
+
+[[package]]
 name = "konst"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,6 +1803,15 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1923,6 +1974,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,6 +2000,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,7 +2023,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1974,6 +2043,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "ogg"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdab8dcd8d4052eaacaf8fb07a3ccd9a6e26efadb42878a413c68fc4af1dee2b"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "pin-project",
+ "tokio",
+ "tokio-util 0.6.10",
 ]
 
 [[package]]
@@ -2000,7 +2084,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2029,12 +2113,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "opus"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3809943dff6fbad5f0484449ea26bdb9cb7d8efdf26ed50d3c7f227f69eb5c"
+dependencies = [
+ "audiopus_sys",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -2148,6 +2264,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
 ]
 
 [[package]]
@@ -2354,12 +2479,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "redb"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2436,7 +2579,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tokio-util",
+ "tokio-util 0.7.19",
  "tower",
  "tower-http",
  "tower-service",
@@ -2476,6 +2619,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rubato"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5d18b486e7d29a408ef3f825bc1327d8f87af091c987ca2f5b734625940e234"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,12 +2646,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2628,12 +2797,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2788,6 +2963,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2866,6 +3051,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2882,6 +3073,201 @@ name = "symlink"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-adpcm",
+ "symphonia-codec-alac",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-caf",
+ "symphonia-format-isomp4",
+ "symphonia-format-mkv",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-alac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-caf"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
+]
 
 [[package]]
 name = "syn"
@@ -2945,7 +3331,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3120,7 +3506,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -3155,6 +3543,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3217,7 +3620,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -3326,6 +3729,16 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]
@@ -3926,7 +4339,7 @@ dependencies = [
  "static_assertions",
  "thiserror 2.0.19",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.19",
  "tracing",
  "uuid",
  "web-time",
@@ -3954,7 +4367,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.19",
  "tokio_with_wasm",
  "tracing",
  "url",
@@ -3995,7 +4408,7 @@ dependencies = [
  "sysinfo",
  "thiserror 2.0.19",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.19",
  "tokio_with_wasm",
  "tracing",
  "tracing-appender",
@@ -4016,6 +4429,20 @@ dependencies = [
  "num-traits",
  "thiserror 1.0.69",
  "zip",
+]
+
+[[package]]
+name = "xla-moshi"
+version = "0.3.1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hf-hub",
+ "kaudio",
+ "serde",
+ "serde_json",
+ "xla",
+ "xla-nn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["xla", "xla-nn"]
+members = ["xla", "xla-nn", "xla-moshi"]
 resolver = "2"
 
 [workspace.package]
@@ -14,7 +14,10 @@ license = "MIT/Apache-2.0"
 
 [workspace.dependencies]
 xla = { path = "xla", version = "0.3.1" }
+xla-nn = { path = "xla-nn", version = "0.3.1" }
 thiserror = "1"
+kaudio = "0.2.1"
+serde = { version = "1.0", features = ["derive"] }
 libc = "0.2"
 num-traits = "0.2"
 num-derive = "0.4"

--- a/xla-moshi/Cargo.toml
+++ b/xla-moshi/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "xla-moshi"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+description = "Moshi / Mimi models built on top of the xla crate."
+
+[dependencies]
+xla = { workspace = true }
+xla-nn = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+hf-hub = { workspace = true }
+kaudio = { workspace = true }

--- a/xla-moshi/build.rs
+++ b/xla-moshi/build.rs
@@ -1,0 +1,22 @@
+// The xla crate's build script links libxla_extension and embeds an rpath into
+// its own targets, but `cargo:rustc-link-arg` does not propagate to dependent
+// crates. Re-emit the rpath here so the binaries built in this crate (the
+// examples) can find libxla_extension.so at runtime, matching the xla crate.
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=XLA_EXTENSION_DIR");
+    let os = env::var("CARGO_CFG_TARGET_OS").expect("Unable to get TARGET_OS");
+    if os != "linux" && os != "macos" {
+        return;
+    }
+    let xla_dir = env::var("XLA_EXTENSION_DIR")
+        .map_or_else(|_| env::current_dir().unwrap().join("xla_extension"), PathBuf::from);
+    let lib = xla_dir.join("lib");
+    if os == "macos" {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{}", lib.display());
+    } else {
+        println!("cargo:rustc-link-arg=-Wl,-rpath={}", lib.display());
+    }
+}

--- a/xla-moshi/examples/moshi.rs
+++ b/xla-moshi/examples/moshi.rs
@@ -1,0 +1,159 @@
+// Mimi audio-codec example: encode an audio file to discrete codes and decode
+// them back to a waveform, all in a single compiled XLA computation (the
+// non-streaming / whole-file path).
+//
+// The model weights are downloaded automatically from the hugging face hub.
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use xla::{ElementType, PjRtClient, XlaBuilder};
+use xla_moshi::mimi::{self, Mimi};
+use xla_moshi::Vb;
+
+#[derive(Parser, Debug)]
+#[command(name = "moshi", about = "Mimi audio processing tool")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Encode audio to codes and decode back to audio using Mimi.
+    AudioToAudio {
+        /// Input audio file to process.
+        input: std::path::PathBuf,
+
+        /// Output WAV file path.
+        #[arg(short, long, default_value = "output.wav")]
+        output: std::path::PathBuf,
+
+        /// Number of codebooks to use.
+        #[arg(short, long, default_value_t = 16)]
+        codebooks: usize,
+
+        /// Use CPU even if an accelerator is available.
+        #[arg(long, default_value_t = false)]
+        cpu: bool,
+    },
+}
+
+fn download_mimi_model() -> Result<std::path::PathBuf> {
+    let repo_id = "kyutai/moshiko-candle-q8";
+    let filename = "tokenizer-e351c8d8-checkpoint125.safetensors";
+    println!("Downloading mimi model from {repo_id}...");
+    let client = hf_hub::HFClientSync::new()?;
+    let (owner, name) = repo_id.split_once('/').context("invalid repo")?;
+    let path = client.model(owner, name).download_file().filename(filename).send()?;
+    println!("  Mimi at {}", path.display());
+    Ok(path)
+}
+
+fn audio_to_audio(
+    input: std::path::PathBuf,
+    output: std::path::PathBuf,
+    codebooks: usize,
+    cpu: bool,
+) -> Result<()> {
+    let target_sample_rate: usize = 24000;
+    let frame_size: usize = 1920;
+
+    // --- Load and resample audio ---
+    println!("Loading audio from {}...", input.display());
+    let (pcm_data, sample_rate) = kaudio::pcm_decode(&input)?;
+    println!(
+        "  {} samples at {} Hz ({:.2}s)",
+        pcm_data.len(),
+        sample_rate,
+        pcm_data.len() as f64 / sample_rate as f64
+    );
+    let pcm_data = if sample_rate as usize != target_sample_rate {
+        println!("  Resampling {sample_rate} Hz -> {target_sample_rate} Hz");
+        kaudio::resample(&pcm_data, sample_rate as usize, target_sample_rate)?
+    } else {
+        pcm_data
+    };
+    let orig_len = pcm_data.len();
+    // Pad up to a whole number of frames, as the reference does per chunk.
+    let num_frames = orig_len.div_ceil(frame_size);
+    let mut pcm_data = pcm_data;
+    pcm_data.resize(num_frames * frame_size, 0.0);
+    let len = pcm_data.len();
+    let audio_duration = orig_len as f64 / target_sample_rate as f64;
+
+    // --- Model + device ---
+    let model_path = download_mimi_model()?;
+    let client = if cpu { PjRtClient::cpu()? } else { PjRtClient::auto(false)? };
+    let config = mimi::Config::v0_1(Some(codebooks));
+    println!(
+        "  sample_rate={}, frame_rate={}, codebooks={codebooks}",
+        config.sample_rate, config.frame_rate
+    );
+
+    // --- Build the encode->decode computation ---
+    println!("Building the computation ({num_frames} frames)...");
+    let start = std::time::Instant::now();
+    let builder = XlaBuilder::new("mimi");
+    let audio = builder.parameter(0, ElementType::F32, &[1, 1, len as i64], "audio")?;
+    let vb_inner = xla_nn::VarBuilder::new(&builder, ElementType::F32, 1);
+    let vb = Vb::new(&vb_inner);
+    let model = Mimi::load(&vb, config)?;
+    let codes = model.encode(&audio)?;
+    let decoded = model.decode(&codes)?;
+    let computation = builder.tuple(&[&codes, &decoded])?.build()?;
+    let exe = client.compile(&computation)?;
+    println!("  built and compiled in {:?}", start.elapsed());
+
+    // --- Load weights and run ---
+    println!("Loading weights...");
+    let start = std::time::Instant::now();
+    let weight_buffers = vb_inner.load_buffers(&[&model_path], &client)?;
+    // Assert every tensor in the checkpoint was consumed. The codebook running
+    // statistics are only used during training, and the checkpoint ships more
+    // codebooks than we decode, so those are ignored.
+    vb_inner.check_all_used_with_ignore(&[&model_path], |name| {
+        name.ends_with("_codebook._initialized")
+            || name.ends_with("_codebook.cluster_usage")
+            || name.ends_with("_codebook.embedding_sum")
+    })?;
+    let audio_buffer = client.buffer_from_host_buffer(&pcm_data, &[1, 1, len], None)?;
+    let mut inputs: Vec<&xla::PjRtBuffer> = vec![&audio_buffer];
+    inputs.extend(weight_buffers.iter());
+    println!("  loaded {} weights in {:?}", weight_buffers.len(), start.elapsed());
+
+    println!("Running encode + decode...");
+    let start = std::time::Instant::now();
+    let outputs = exe.execute_b(&inputs)?;
+    let outputs = outputs.into_iter().next().context("no execution outputs")?;
+    let codes_lit = outputs[0].to_literal_sync()?;
+    let decoded_lit = outputs[1].to_literal_sync()?;
+    let elapsed = start.elapsed();
+
+    let codes_shape = codes_lit.array_shape()?;
+    let codes_vec = codes_lit.to_vec::<i64>()?;
+    println!(
+        "  done in {:.2}s ({:.1}x realtime)",
+        elapsed.as_secs_f64(),
+        audio_duration / elapsed.as_secs_f64()
+    );
+    println!("Codes shape: {:?} (batch, codebooks, frames)", codes_shape.dims());
+    let n_show = codes_vec.len().min(32);
+    println!("First {n_show} codes: {:?}", &codes_vec[..n_show]);
+
+    // --- Write the reconstructed audio ---
+    let decoded_pcm: Vec<f32> = decoded_lit.to_vec::<f32>()?.into_iter().take(orig_len).collect();
+    println!("Writing {} samples to {}...", decoded_pcm.len(), output.display());
+    let file = std::fs::File::create(&output)?;
+    let mut writer = std::io::BufWriter::new(file);
+    kaudio::wav::write_pcm_as_wav(&mut writer, &decoded_pcm, target_sample_rate as u32, 1)?;
+    println!("Done.");
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::AudioToAudio { input, output, codebooks, cpu } => {
+            audio_to_audio(input, output, codebooks, cpu)
+        }
+    }
+}

--- a/xla-moshi/src/conv.rs
+++ b/xla-moshi/src/conv.rs
@@ -25,12 +25,7 @@ pub enum PadMode {
     Replicate,
 }
 
-fn get_extra_padding_for_conv1d(
-    len: i64,
-    k_size_eff: i64,
-    stride: i64,
-    padding_total: i64,
-) -> i64 {
+fn get_extra_padding_for_conv1d(len: i64, k_size_eff: i64, stride: i64, padding_total: i64) -> i64 {
     let n_frames = (len + padding_total - k_size_eff).max(0) as f64 / stride as f64 + 1.0;
     let ideal_len = ((n_frames.ceil() as i64 - 1) * stride + k_size_eff - padding_total).max(0);
     (ideal_len - len).max(0)

--- a/xla-moshi/src/conv.rs
+++ b/xla-moshi/src/conv.rs
@@ -1,0 +1,226 @@
+//! Streamable 1D convolutions, ported from the `xn-moshi` reference but running
+//! over the whole sequence at once (non-streaming). Only the forward path is
+//! implemented.
+//!
+//! Weight-norm is assumed to be pre-fused into a single `weight` tensor, which
+//! is the case for the candle-format Mimi checkpoints used by the AudioToAudio
+//! example.
+use crate::{add_bias, Result, Vb};
+use xla::XlaOp;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Norm {
+    WeightNorm,
+    SpectralNorm,
+    TimeGroupNorm,
+    None,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PadMode {
+    Constant,
+    Reflect,
+    Replicate,
+}
+
+fn get_extra_padding_for_conv1d(
+    len: i64,
+    k_size_eff: i64,
+    stride: i64,
+    padding_total: i64,
+) -> i64 {
+    let n_frames = (len + padding_total - k_size_eff).max(0) as f64 / stride as f64 + 1.0;
+    let ideal_len = ((n_frames.ceil() as i64 - 1) * stride + k_size_eff - padding_total).max(0);
+    (ideal_len - len).max(0)
+}
+
+fn pad1d(xs: &XlaOp, pad_l: i64, pad_r: i64, mode: PadMode) -> Result<XlaOp> {
+    match mode {
+        PadMode::Constant => {
+            let zero = xs.builder().c0(0f32)?;
+            Ok(xs.pad_in_dim(&zero, 2, pad_l, pad_r)?)
+        }
+        PadMode::Replicate => pad_replicate(xs, pad_l, pad_r),
+        PadMode::Reflect => Err(crate::Error::Xla(xla::Error::XlaError {
+            msg: "pad-mode 'reflect' is not supported".to_string(),
+            backtrace: String::new(),
+        })),
+    }
+}
+
+/// Edge (replicate) padding along the time dimension.
+fn pad_replicate(xs: &XlaOp, pad_l: i64, pad_r: i64) -> Result<XlaOp> {
+    let dims = xs.dims()?;
+    let (b, c, len) = (dims[0] as i64, dims[1] as i64, dims[2] as i64);
+    let mut parts: Vec<XlaOp> = Vec::new();
+    if pad_l > 0 {
+        let edge = xs.slice_in_dim1(0, 1, 2)?;
+        parts.push(edge.broadcast_in_dim(&[b, c, pad_l], &[0, 1, 2])?);
+    }
+    parts.push(xs.clone());
+    if pad_r > 0 {
+        let edge = xs.slice_in_dim1(len - 1, len, 2)?;
+        parts.push(edge.broadcast_in_dim(&[b, c, pad_r], &[0, 1, 2])?);
+    }
+    if parts.len() == 1 {
+        return Ok(parts.pop().unwrap());
+    }
+    let first = parts.remove(0);
+    Ok(first.concat_in_dim(&parts, 2)?)
+}
+
+fn unpad1d(xs: &XlaOp, unpad_l: i64, unpad_r: i64) -> Result<XlaOp> {
+    let len = xs.dims()?[2] as i64;
+    Ok(xs.slice_in_dim1(unpad_l, len - unpad_r, 2)?)
+}
+
+pub struct StreamableConv1d {
+    weight: XlaOp,
+    bias: Option<XlaOp>,
+    stride: i64,
+    dilation: i64,
+    groups: i64,
+    kernel_size: i64,
+    causal: bool,
+    pad_mode: PadMode,
+}
+
+impl StreamableConv1d {
+    #[allow(clippy::too_many_arguments)]
+    pub fn load(
+        vb: &Vb,
+        in_c: i64,
+        out_c: i64,
+        k_size: i64,
+        stride: i64,
+        dilation: i64,
+        groups: i64,
+        bias: bool,
+        causal: bool,
+        _norm: Option<Norm>,
+        pad_mode: PadMode,
+    ) -> Result<Self> {
+        let vb = vb.pp("conv").pp("conv");
+        let weight = vb.var("weight", &[out_c, in_c / groups, k_size])?;
+        let bias = if bias { Some(vb.var("bias", &[out_c])?) } else { None };
+        Ok(Self { weight, bias, stride, dilation, groups, kernel_size: k_size, causal, pad_mode })
+    }
+
+    pub fn forward(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let k_size_eff = (self.kernel_size - 1) * self.dilation + 1;
+        let padding_total = k_size_eff - self.stride;
+        let len = xs.dims()?[2] as i64;
+        let extra = get_extra_padding_for_conv1d(len, k_size_eff, self.stride, padding_total);
+        let xs = if self.causal {
+            pad1d(xs, padding_total, extra, self.pad_mode)?
+        } else {
+            let padding_right = padding_total / 2;
+            let padding_left = padding_total - padding_right;
+            pad1d(xs, padding_left, padding_right + extra, self.pad_mode)?
+        };
+        let ys = xs.conv1d(&self.weight, self.stride, 0, self.dilation, self.groups)?;
+        match &self.bias {
+            Some(b) => add_bias(&ys, b),
+            None => Ok(ys),
+        }
+    }
+}
+
+pub struct StreamableConvTranspose1d {
+    weight: XlaOp,
+    bias: Option<XlaOp>,
+    k_size: i64,
+    stride: i64,
+    groups: i64,
+    causal: bool,
+}
+
+impl StreamableConvTranspose1d {
+    #[allow(clippy::too_many_arguments)]
+    pub fn load(
+        vb: &Vb,
+        in_c: i64,
+        out_c: i64,
+        k_size: i64,
+        stride: i64,
+        groups: i64,
+        bias: bool,
+        causal: bool,
+        _norm: Option<Norm>,
+    ) -> Result<Self> {
+        let vb = vb.pp("convtr").pp("convtr");
+        let weight = vb.var("weight", &[in_c, out_c / groups, k_size])?;
+        let bias = if bias { Some(vb.var("bias", &[out_c])?) } else { None };
+        Ok(Self { weight, bias, k_size, stride, groups, causal })
+    }
+
+    pub fn forward(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let padding_total = (self.k_size - self.stride).max(0);
+        let ys = xs.conv_transpose1d(&self.weight, self.stride, 0, 0, 1, self.groups)?;
+        let ys = match &self.bias {
+            Some(b) => add_bias(&ys, b)?,
+            None => ys,
+        };
+        if self.causal {
+            unpad1d(&ys, 0, padding_total)
+        } else {
+            let padding_right = padding_total / 2;
+            let padding_left = padding_total - padding_right;
+            unpad1d(&ys, padding_left, padding_right)
+        }
+    }
+}
+
+pub struct ConvDownsample1d {
+    conv: StreamableConv1d,
+}
+
+impl ConvDownsample1d {
+    pub fn load(vb: &Vb, stride: i64, dim: i64, causal: bool) -> Result<Self> {
+        let conv = StreamableConv1d::load(
+            &vb.pp("conv"),
+            dim,
+            dim,
+            2 * stride,
+            stride,
+            1,
+            1,
+            false,
+            causal,
+            None,
+            PadMode::Replicate,
+        )?;
+        Ok(Self { conv })
+    }
+
+    pub fn forward(&self, xs: &XlaOp) -> Result<XlaOp> {
+        self.conv.forward(xs)
+    }
+}
+
+pub struct ConvTrUpsample1d {
+    convtr: StreamableConvTranspose1d,
+}
+
+impl ConvTrUpsample1d {
+    pub fn load(vb: &Vb, stride: i64, dim: i64, causal: bool) -> Result<Self> {
+        let convtr = StreamableConvTranspose1d::load(
+            &vb.pp("convtr"),
+            dim,
+            dim,
+            2 * stride,
+            stride,
+            dim, // depthwise
+            false,
+            causal,
+            None,
+        )?;
+        Ok(Self { convtr })
+    }
+
+    pub fn forward(&self, xs: &XlaOp) -> Result<XlaOp> {
+        self.convtr.forward(xs)
+    }
+}

--- a/xla-moshi/src/lib.rs
+++ b/xla-moshi/src/lib.rs
@@ -1,0 +1,62 @@
+//! Moshi / Mimi models built on top of the [`xla`] crate.
+//!
+//! This currently implements the non-streaming (whole-file) forward path of the
+//! Mimi neural audio codec: SEANet encoder/decoder, the Mimi transformer, and
+//! the split residual vector quantizer. The implementation mirrors the eager
+//! `xn-moshi` reference but builds a single XLA computation for `encode` and one
+//! for `decode`.
+pub mod conv;
+pub mod mimi;
+pub mod quantization;
+pub mod seanet;
+pub mod transformer;
+
+pub use xla_nn::{Error, Result};
+
+use xla::XlaOp;
+
+/// A thin helper that mirrors the `Path` used in the `xn` reference: it keeps a
+/// dotted prefix and forwards weight declarations to an [`xla_nn::VarBuilder`],
+/// so the safetensors names line up exactly with the reference implementation.
+#[derive(Clone)]
+pub struct Vb<'a> {
+    inner: &'a xla_nn::VarBuilder,
+    prefix: String,
+}
+
+impl<'a> Vb<'a> {
+    pub fn new(inner: &'a xla_nn::VarBuilder) -> Self {
+        Self { inner, prefix: String::new() }
+    }
+
+    /// Push a component onto the prefix (like `cd`-ing into a directory).
+    pub fn pp(&self, s: impl std::fmt::Display) -> Vb<'a> {
+        let prefix =
+            if self.prefix.is_empty() { s.to_string() } else { format!("{}.{s}", self.prefix) };
+        Vb { inner: self.inner, prefix }
+    }
+
+    fn key(&self, name: &str) -> String {
+        if self.prefix.is_empty() {
+            name.to_string()
+        } else {
+            format!("{}.{name}", self.prefix)
+        }
+    }
+
+    /// Declare a weight parameter and return the corresponding graph node.
+    pub fn var(&self, name: &str, dims: &[i64]) -> Result<XlaOp> {
+        self.inner.var(&self.key(name), dims)
+    }
+
+    pub fn var_builder(&self) -> &'a xla_nn::VarBuilder {
+        self.inner
+    }
+}
+
+/// Broadcast-add a per-channel bias of shape `[c]` onto a `[b, c, t]` tensor.
+pub(crate) fn add_bias(xs: &XlaOp, bias: &XlaOp) -> Result<XlaOp> {
+    let c = bias.dims()?[0] as i64;
+    let bias = bias.reshape(&[1, c, 1])?;
+    Ok(xs.add_(&bias)?)
+}

--- a/xla-moshi/src/mimi.rs
+++ b/xla-moshi/src/mimi.rs
@@ -1,0 +1,164 @@
+//! The Mimi neural audio codec, ported from `xn-moshi`. Provides the
+//! non-streaming (whole-file) `encode` and `decode` graph builders.
+use crate::conv::{ConvDownsample1d, ConvTrUpsample1d, Norm, PadMode};
+use crate::quantization::SplitResidualVectorQuantizer;
+use crate::seanet::{self, SeaNetDecoder, SeaNetEncoder};
+use crate::transformer::{self, PositionalEmbedding, ProjectedTransformer};
+use crate::{Result, Vb};
+use xla::XlaOp;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ResampleMethod {
+    Conv,
+    Interpolate,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Config {
+    pub channels: usize,
+    pub sample_rate: f64,
+    pub frame_rate: f64,
+    pub renormalize: bool,
+    pub resample_method: ResampleMethod,
+    pub seanet: seanet::Config,
+    pub transformer: transformer::Config,
+    pub quantizer_n_q: usize,
+    pub quantizer_bins: usize,
+    pub quantizer_dim: usize,
+}
+
+impl Config {
+    pub fn v0_1(num_codebooks: Option<usize>) -> Self {
+        let seanet = seanet::Config {
+            dimension: 512,
+            channels: 1,
+            causal: true,
+            n_filters: 64,
+            n_residual_layers: 1,
+            activation: seanet::Activation::Elu(1.),
+            compress: 2,
+            dilation_base: 2,
+            disable_norm_outer_blocks: 0,
+            final_activation: None,
+            kernel_size: 7,
+            residual_kernel_size: 3,
+            last_kernel_size: 3,
+            lstm: None,
+            norm: Norm::WeightNorm,
+            pad_mode: PadMode::Constant,
+            ratios: vec![8, 6, 5, 4],
+            true_skip: true,
+        };
+        let transformer = transformer::Config {
+            d_model: seanet.dimension,
+            num_heads: 8,
+            num_layers: 8,
+            causal: true,
+            norm_first: true,
+            bias_ff: false,
+            bias_attn: false,
+            layer_scale: Some(0.01),
+            context: 250,
+            use_conv_block: false,
+            max_period: 10000.0,
+            positional_embedding: PositionalEmbedding::Rope,
+            dim_feedforward: 2048,
+            kv_repeat: 1,
+            conv_layout: true,
+        };
+        Config {
+            channels: 1,
+            sample_rate: 24_000.,
+            frame_rate: 12.5,
+            renormalize: true,
+            resample_method: ResampleMethod::Conv,
+            seanet,
+            transformer,
+            quantizer_n_q: num_codebooks.unwrap_or(16),
+            quantizer_bins: 2048,
+            quantizer_dim: 256,
+        }
+    }
+}
+
+pub struct Mimi {
+    encoder: SeaNetEncoder,
+    decoder: SeaNetDecoder,
+    encoder_transformer: ProjectedTransformer,
+    decoder_transformer: ProjectedTransformer,
+    downsample: ConvDownsample1d,
+    upsample: ConvTrUpsample1d,
+    quantizer: SplitResidualVectorQuantizer,
+    config: Config,
+}
+
+impl Mimi {
+    pub fn load(vb: &Vb, cfg: Config) -> Result<Self> {
+        let dim = cfg.seanet.dimension as i64;
+        let encoder = SeaNetEncoder::load(&vb.pp("encoder"), &cfg.seanet)?;
+        let decoder = SeaNetDecoder::load(&vb.pp("decoder"), &cfg.seanet)?;
+        let encoder_transformer =
+            ProjectedTransformer::load(&vb.pp("encoder_transformer"), dim, &cfg.transformer)?;
+        let decoder_transformer =
+            ProjectedTransformer::load(&vb.pp("decoder_transformer"), dim, &cfg.transformer)?;
+        let quantizer = SplitResidualVectorQuantizer::load(
+            &vb.pp("quantizer"),
+            cfg.quantizer_dim as i64,
+            Some(dim),
+            Some(dim),
+            cfg.quantizer_n_q as i64,
+            cfg.quantizer_bins as i64,
+        )?;
+        let encoder_frame_rate =
+            cfg.sample_rate / cfg.seanet.ratios.iter().product::<usize>() as f64;
+        let downsample_stride = (encoder_frame_rate / cfg.frame_rate) as i64;
+        let downsample = ConvDownsample1d::load(&vb.pp("downsample"), downsample_stride, dim, true)?;
+        let upsample = ConvTrUpsample1d::load(&vb.pp("upsample"), downsample_stride, dim, true)?;
+        Ok(Self {
+            encoder,
+            decoder,
+            encoder_transformer,
+            decoder_transformer,
+            downsample,
+            upsample,
+            quantizer,
+            config: cfg,
+        })
+    }
+
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    /// Encode audio `[batch, 1, len]` to integer codes `[batch, n_q, frames]`.
+    pub fn encode(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let xs = self.encoder.forward(xs)?;
+        let xs = self.encoder_transformer.forward(&xs)?;
+        let xs = self.downsample.forward(&xs)?;
+        self.quantizer.encode(&xs)
+    }
+
+    /// Decode integer codes `[batch, n_q, frames]` to audio `[batch, 1, len]`.
+    pub fn decode(&self, codes: &XlaOp) -> Result<XlaOp> {
+        let emb = self.quantizer.decode(codes)?;
+        let emb = self.upsample.forward(&emb)?;
+        let outs = self.decoder_transformer.forward(&emb)?;
+        self.decoder.forward(&outs)
+    }
+
+    /// Encoder + transformer + downsample, before quantization.
+    pub fn encode_pre_quantize(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let xs = self.encoder.forward(xs)?;
+        let xs = self.encoder_transformer.forward(&xs)?;
+        self.downsample.forward(&xs)
+    }
+
+    /// Debug: per-stage decode tensors (emb, upsampled, post-transformer, final).
+    pub fn decode_stages(&self, codes: &XlaOp) -> Result<Vec<XlaOp>> {
+        let emb = self.quantizer.decode(codes)?;
+        let up = self.upsample.forward(&emb)?;
+        let dtf = self.decoder_transformer.forward(&up)?;
+        let out = self.decoder.forward(&dtf)?;
+        Ok(vec![emb, up, dtf, out])
+    }
+}

--- a/xla-moshi/src/mimi.rs
+++ b/xla-moshi/src/mimi.rs
@@ -112,7 +112,8 @@ impl Mimi {
         let encoder_frame_rate =
             cfg.sample_rate / cfg.seanet.ratios.iter().product::<usize>() as f64;
         let downsample_stride = (encoder_frame_rate / cfg.frame_rate) as i64;
-        let downsample = ConvDownsample1d::load(&vb.pp("downsample"), downsample_stride, dim, true)?;
+        let downsample =
+            ConvDownsample1d::load(&vb.pp("downsample"), downsample_stride, dim, true)?;
         let upsample = ConvTrUpsample1d::load(&vb.pp("upsample"), downsample_stride, dim, true)?;
         Ok(Self {
             encoder,

--- a/xla-moshi/src/quantization.rs
+++ b/xla-moshi/src/quantization.rs
@@ -70,12 +70,7 @@ pub struct VectorQuantization {
 }
 
 impl VectorQuantization {
-    pub fn load(
-        vb: &Vb,
-        dim: i64,
-        codebook_size: i64,
-        codebook_dim: Option<i64>,
-    ) -> Result<Self> {
+    pub fn load(vb: &Vb, dim: i64, codebook_size: i64, codebook_dim: Option<i64>) -> Result<Self> {
         let codebook_dim = codebook_dim.unwrap_or(dim);
         let (project_in, project_out) = if codebook_dim == dim {
             (None, None)
@@ -153,8 +148,9 @@ impl ResidualVectorQuantization {
         let mut quantized: Option<XlaOp> = None;
         for (i, layer) in self.layers.iter().enumerate() {
             let d = codes.dims()?;
-            let layer_codes =
-                codes.slice_in_dim1(i as i64, i as i64 + 1, 1)?.reshape(&[d[0] as i64, d[2] as i64])?;
+            let layer_codes = codes
+                .slice_in_dim1(i as i64, i as i64 + 1, 1)?
+                .reshape(&[d[0] as i64, d[2] as i64])?;
             let q = layer.decode(&layer_codes)?;
             quantized = Some(match quantized {
                 None => q,
@@ -235,8 +231,15 @@ impl SplitResidualVectorQuantizer {
         n_q: i64,
         bins: i64,
     ) -> Result<Self> {
-        let rvq_first =
-            ResidualVectorQuantizer::load(&vb.pp("rvq_first"), dim, input_dim, output_dim, 1, bins, true)?;
+        let rvq_first = ResidualVectorQuantizer::load(
+            &vb.pp("rvq_first"),
+            dim,
+            input_dim,
+            output_dim,
+            1,
+            bins,
+            true,
+        )?;
         let rvq_rest = ResidualVectorQuantizer::load(
             &vb.pp("rvq_rest"),
             dim,

--- a/xla-moshi/src/quantization.rs
+++ b/xla-moshi/src/quantization.rs
@@ -1,0 +1,274 @@
+//! Residual vector quantization, ported from the `xn-moshi` reference.
+use crate::{Result, Vb};
+use xla::{ElementType, XlaOp};
+
+/// Contract the last dim of `xs` with the last dim of `w` (i.e. `xs @ w^T`),
+/// keeping any leading/batch dims of `xs`.
+fn matmul_t(xs: &XlaOp, w: &XlaOp) -> Result<XlaOp> {
+    let rank = xs.rank()? as i64;
+    Ok(xs.dot_general(w, &[rank - 1], &[1], &[], &[])?)
+}
+
+pub struct EuclideanCodebook {
+    embedding: XlaOp,
+    c2: XlaOp,
+    dim: i64,
+}
+
+impl EuclideanCodebook {
+    pub fn load(vb: &Vb, dim: i64, codebook_size: i64) -> Result<Self> {
+        let cluster_usage = vb.var("cluster_usage", &[codebook_size])?;
+        let embedding_sum = vb.var("embedding_sum", &[codebook_size, dim])?;
+        let b = cluster_usage.builder();
+        // embedding = embedding_sum / max(cluster_usage, eps)
+        let eps = b.c0(1e-5f32)?;
+        let cluster_usage = cluster_usage.max(&eps)?.reshape(&[codebook_size, 1])?;
+        let cluster_usage = cluster_usage.broadcast_in_dim(&[codebook_size, dim], &[0, 1])?;
+        let embedding = embedding_sum.div_(&cluster_usage)?;
+        // c2 = 0.5 * sum(embedding^2, dim=-1)
+        let c2 = embedding.mul_(&embedding)?.reduce_sum(&[1], false)?;
+        let c2 = c2.mul_(&b.c0(0.5f32)?)?;
+        Ok(Self { embedding, c2, dim })
+    }
+
+    /// `xs`: `[.., dim]` -> codes `[..]` (S64).
+    pub fn encode(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let dims = xs.dims()?;
+        let mut target: Vec<i64> = dims.iter().map(|d| *d as i64).collect();
+        target.pop();
+        let n: i64 = target.iter().product::<i64>().max(1);
+        let flat = xs.reshape(&[n, self.dim])?;
+        // dist = c2 - x . e (the ||x||^2 term is constant and does not shift the argmin).
+        let dot = flat.dot_general(&self.embedding, &[1], &[1], &[], &[])?;
+        let bins = self.c2.dims()?[0] as i64;
+        let c2 = self.c2.broadcast_in_dim(&[n, bins], &[1])?;
+        let dists = c2.sub_(&dot)?;
+        let codes = dists.argmin(ElementType::S64, 1)?;
+        if target.is_empty() {
+            Ok(codes)
+        } else {
+            Ok(codes.reshape(&target)?)
+        }
+    }
+
+    /// `indices`: `[..]` -> `[.., dim]`.
+    pub fn decode(&self, indices: &XlaOp) -> Result<XlaOp> {
+        let dims = indices.dims()?;
+        let mut final_dims: Vec<i64> = dims.iter().map(|d| *d as i64).collect();
+        let n: i64 = final_dims.iter().product::<i64>().max(1);
+        final_dims.push(self.dim);
+        let flat = indices.reshape(&[n])?;
+        let values = self.embedding.take(&flat, 0)?;
+        Ok(values.reshape(&final_dims)?)
+    }
+}
+
+pub struct VectorQuantization {
+    project_in: Option<XlaOp>,
+    project_out: Option<XlaOp>,
+    codebook: EuclideanCodebook,
+}
+
+impl VectorQuantization {
+    pub fn load(
+        vb: &Vb,
+        dim: i64,
+        codebook_size: i64,
+        codebook_dim: Option<i64>,
+    ) -> Result<Self> {
+        let codebook_dim = codebook_dim.unwrap_or(dim);
+        let (project_in, project_out) = if codebook_dim == dim {
+            (None, None)
+        } else {
+            let p_in = vb.pp("project_in").var("weight", &[codebook_dim, dim])?;
+            let p_out = vb.pp("project_out").var("weight", &[dim, codebook_dim])?;
+            (Some(p_in), Some(p_out))
+        };
+        let codebook = EuclideanCodebook::load(&vb.pp("_codebook"), codebook_dim, codebook_size)?;
+        Ok(Self { project_in, project_out, codebook })
+    }
+
+    /// `xs`: `[b, c, t]` -> codes `[b, t]`.
+    pub fn encode(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let xs = xs.swap_dims(1, 2)?;
+        let xs = match &self.project_in {
+            Some(p) => matmul_t(&xs, p)?,
+            None => xs,
+        };
+        self.codebook.encode(&xs)
+    }
+
+    /// codes `[b, t]` -> `[b, c, t]`.
+    pub fn decode(&self, codes: &XlaOp) -> Result<XlaOp> {
+        let q = self.codebook.decode(codes)?;
+        let q = match &self.project_out {
+            Some(p) => matmul_t(&q, p)?,
+            None => q,
+        };
+        Ok(q.swap_dims(1, 2)?)
+    }
+}
+
+pub struct ResidualVectorQuantization {
+    layers: Vec<VectorQuantization>,
+}
+
+impl ResidualVectorQuantization {
+    pub fn load(
+        vb: &Vb,
+        n_q: i64,
+        dim: i64,
+        codebook_size: i64,
+        codebook_dim: Option<i64>,
+    ) -> Result<Self> {
+        let vb = vb.pp("layers");
+        let mut layers = Vec::with_capacity(n_q as usize);
+        for i in 0..n_q {
+            layers.push(VectorQuantization::load(&vb.pp(i), dim, codebook_size, codebook_dim)?);
+        }
+        Ok(Self { layers })
+    }
+
+    /// `xs`: `[b, dim, t]` -> codes `[b, n_q, t]`.
+    pub fn encode(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let mut residual = xs.clone();
+        let mut codes: Vec<XlaOp> = Vec::with_capacity(self.layers.len());
+        for layer in &self.layers {
+            let indices = layer.encode(&residual)?; // [b, t]
+            let quantized = layer.decode(&indices)?; // [b, dim, t]
+            residual = residual.sub_(&quantized)?;
+            let d = indices.dims()?;
+            codes.push(indices.reshape(&[d[0] as i64, 1, d[1] as i64])?);
+        }
+        let first = codes.remove(0);
+        if codes.is_empty() {
+            Ok(first)
+        } else {
+            Ok(first.concat_in_dim(&codes, 1)?)
+        }
+    }
+
+    /// codes `[b, n_q, t]` -> `[b, dim, t]`.
+    pub fn decode(&self, codes: &XlaOp) -> Result<XlaOp> {
+        let mut quantized: Option<XlaOp> = None;
+        for (i, layer) in self.layers.iter().enumerate() {
+            let d = codes.dims()?;
+            let layer_codes =
+                codes.slice_in_dim1(i as i64, i as i64 + 1, 1)?.reshape(&[d[0] as i64, d[2] as i64])?;
+            let q = layer.decode(&layer_codes)?;
+            quantized = Some(match quantized {
+                None => q,
+                Some(acc) => acc.add_(&q)?,
+            });
+        }
+        quantized.ok_or_else(|| {
+            crate::Error::Xla(xla::Error::XlaError {
+                msg: "empty layers in ResidualVectorQuantization".to_string(),
+                backtrace: String::new(),
+            })
+        })
+    }
+}
+
+pub struct ResidualVectorQuantizer {
+    vq: ResidualVectorQuantization,
+    input_proj: Option<XlaOp>,
+    output_proj: Option<XlaOp>,
+}
+
+impl ResidualVectorQuantizer {
+    #[allow(clippy::too_many_arguments)]
+    pub fn load(
+        vb: &Vb,
+        dim: i64,
+        input_dim: Option<i64>,
+        output_dim: Option<i64>,
+        n_q: i64,
+        bins: i64,
+        force_projection: bool,
+    ) -> Result<Self> {
+        let input_dim = input_dim.unwrap_or(dim);
+        let output_dim = output_dim.unwrap_or(dim);
+        let input_proj = if input_dim != dim || force_projection {
+            Some(vb.pp("input_proj").var("weight", &[dim, input_dim, 1])?)
+        } else {
+            None
+        };
+        let output_proj = if output_dim != dim || force_projection {
+            Some(vb.pp("output_proj").var("weight", &[output_dim, dim, 1])?)
+        } else {
+            None
+        };
+        let vq = ResidualVectorQuantization::load(&vb.pp("vq"), n_q, dim, bins, None)?;
+        Ok(Self { vq, input_proj, output_proj })
+    }
+
+    pub fn encode(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let xs = match &self.input_proj {
+            Some(p) => xs.conv1d(p, 1, 0, 1, 1)?,
+            None => xs.clone(),
+        };
+        self.vq.encode(&xs)
+    }
+
+    pub fn decode(&self, codes: &XlaOp) -> Result<XlaOp> {
+        let quantized = self.vq.decode(codes)?;
+        match &self.output_proj {
+            Some(p) => Ok(quantized.conv1d(p, 1, 0, 1, 1)?),
+            None => Ok(quantized),
+        }
+    }
+}
+
+pub struct SplitResidualVectorQuantizer {
+    rvq_first: ResidualVectorQuantizer,
+    rvq_rest: ResidualVectorQuantizer,
+    n_q: i64,
+}
+
+impl SplitResidualVectorQuantizer {
+    pub fn load(
+        vb: &Vb,
+        dim: i64,
+        input_dim: Option<i64>,
+        output_dim: Option<i64>,
+        n_q: i64,
+        bins: i64,
+    ) -> Result<Self> {
+        let rvq_first =
+            ResidualVectorQuantizer::load(&vb.pp("rvq_first"), dim, input_dim, output_dim, 1, bins, true)?;
+        let rvq_rest = ResidualVectorQuantizer::load(
+            &vb.pp("rvq_rest"),
+            dim,
+            input_dim,
+            output_dim,
+            n_q - 1,
+            bins,
+            true,
+        )?;
+        Ok(Self { rvq_first, rvq_rest, n_q })
+    }
+
+    /// `xs`: `[b, dim, t]` -> codes `[b, n_q, t]`.
+    pub fn encode(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let codes = self.rvq_first.encode(xs)?;
+        if self.n_q > 1 {
+            let rest = self.rvq_rest.encode(xs)?;
+            Ok(codes.concat_in_dim(&[rest], 1)?)
+        } else {
+            Ok(codes)
+        }
+    }
+
+    /// codes `[b, n_q, t]` -> `[b, dim, t]`.
+    pub fn decode(&self, codes: &XlaOp) -> Result<XlaOp> {
+        let first_codes = codes.slice_in_dim1(0, 1, 1)?;
+        let quantized = self.rvq_first.decode(&first_codes)?;
+        if self.n_q > 1 {
+            let rest_codes = codes.slice_in_dim1(1, self.n_q, 1)?;
+            Ok(quantized.add_(&self.rvq_rest.decode(&rest_codes)?)?)
+        } else {
+            Ok(quantized)
+        }
+    }
+}

--- a/xla-moshi/src/seanet.rs
+++ b/xla-moshi/src/seanet.rs
@@ -1,0 +1,364 @@
+//! SEANet encoder/decoder, ported from `xn-moshi` (forward path only).
+use crate::conv::{Norm, PadMode, StreamableConv1d, StreamableConvTranspose1d};
+use crate::{Result, Vb};
+use xla::XlaOp;
+
+#[derive(Debug, Copy, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Activation {
+    Elu(f32),
+    Gelu,
+    Relu,
+    Silu,
+    Tanh,
+    Sigmoid,
+}
+
+impl Activation {
+    pub fn apply(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let b = xs.builder();
+        let zero = b.c0(0f32)?;
+        match self {
+            // elu(x) = max(x, 0) + min(alpha * (exp(x) - 1), 0)
+            Activation::Elu(alpha) => {
+                let pos = xs.max(&zero)?;
+                let neg = xs.expm1()?.mul_(&b.c0(*alpha)?)?.min(&zero)?;
+                Ok(pos.add_(&neg)?)
+            }
+            Activation::Gelu => Ok(xs.gelu_erf()?),
+            Activation::Relu => Ok(xs.max(&zero)?),
+            Activation::Silu => Ok(xs.silu()?),
+            Activation::Tanh => Ok(xs.tanh()?),
+            Activation::Sigmoid => Ok(xs.sigmoid()?),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Config {
+    pub dimension: usize,
+    pub channels: usize,
+    pub causal: bool,
+    pub n_filters: usize,
+    pub n_residual_layers: usize,
+    pub ratios: Vec<usize>,
+    pub activation: Activation,
+    pub norm: Norm,
+    pub kernel_size: usize,
+    pub residual_kernel_size: usize,
+    pub last_kernel_size: usize,
+    pub dilation_base: usize,
+    pub pad_mode: PadMode,
+    pub true_skip: bool,
+    pub compress: usize,
+    pub lstm: Option<usize>,
+    pub disable_norm_outer_blocks: usize,
+    pub final_activation: Option<Activation>,
+}
+
+struct SeaNetResnetBlock {
+    block: Vec<StreamableConv1d>,
+    shortcut: Option<StreamableConv1d>,
+    activation: Activation,
+}
+
+impl SeaNetResnetBlock {
+    #[allow(clippy::too_many_arguments)]
+    fn load(
+        vb: &Vb,
+        dim: i64,
+        k_sizes_and_dilations: &[(i64, i64)],
+        activation: Activation,
+        norm: Option<Norm>,
+        causal: bool,
+        pad_mode: PadMode,
+        compress: i64,
+        true_skip: bool,
+    ) -> Result<Self> {
+        let hidden = dim / compress;
+        let vb_b = vb.pp("block");
+        let n = k_sizes_and_dilations.len();
+        let mut block = Vec::with_capacity(n);
+        for (i, &(k_size, dilation)) in k_sizes_and_dilations.iter().enumerate() {
+            let in_c = if i == 0 { dim } else { hidden };
+            let out_c = if i == n - 1 { dim } else { hidden };
+            block.push(StreamableConv1d::load(
+                &vb_b.pp(2 * i as i64 + 1),
+                in_c,
+                out_c,
+                k_size,
+                1,
+                dilation,
+                1,
+                true,
+                causal,
+                norm,
+                pad_mode,
+            )?);
+        }
+        let shortcut = if true_skip {
+            None
+        } else {
+            Some(StreamableConv1d::load(
+                &vb.pp("shortcut"),
+                dim,
+                dim,
+                1,
+                1,
+                1,
+                1,
+                true,
+                causal,
+                norm,
+                pad_mode,
+            )?)
+        };
+        Ok(Self { block, shortcut, activation })
+    }
+
+    fn forward(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let mut ys = xs.clone();
+        for conv in &self.block {
+            ys = self.activation.apply(&ys)?;
+            ys = conv.forward(&ys)?;
+        }
+        match &self.shortcut {
+            None => Ok(ys.add_(xs)?),
+            Some(shortcut) => Ok(ys.add_(&shortcut.forward(xs)?)?),
+        }
+    }
+}
+
+struct EncoderLayer {
+    residuals: Vec<SeaNetResnetBlock>,
+    downsample: StreamableConv1d,
+}
+
+pub struct SeaNetEncoder {
+    init_conv: StreamableConv1d,
+    activation: Activation,
+    layers: Vec<EncoderLayer>,
+    final_conv: StreamableConv1d,
+}
+
+impl SeaNetEncoder {
+    pub fn load(vb: &Vb, cfg: &Config) -> Result<Self> {
+        if cfg.lstm.unwrap_or(0) > 0 {
+            return Err(err("seanet lstm is not supported"));
+        }
+        let n_blocks = 2 + cfg.ratios.len();
+        let nf = cfg.n_filters as i64;
+        let mut mult = 1i64;
+        let init_norm = if cfg.disable_norm_outer_blocks >= 1 { None } else { Some(cfg.norm) };
+        let mut layer_idx = 0i64;
+        let vb = vb.pp("model");
+        let init_conv = StreamableConv1d::load(
+            &vb.pp(layer_idx),
+            cfg.channels as i64,
+            mult * nf,
+            cfg.kernel_size as i64,
+            1,
+            1,
+            1,
+            true,
+            cfg.causal,
+            init_norm,
+            cfg.pad_mode,
+        )?;
+        layer_idx += 1;
+
+        let mut layers = Vec::with_capacity(cfg.ratios.len());
+        for (i, &ratio) in cfg.ratios.iter().rev().enumerate() {
+            let norm =
+                if cfg.disable_norm_outer_blocks >= i + 2 { None } else { Some(cfg.norm) };
+            let mut residuals = Vec::with_capacity(cfg.n_residual_layers);
+            for j in 0..cfg.n_residual_layers {
+                let dilation = (cfg.dilation_base as i64).pow(j as u32);
+                residuals.push(SeaNetResnetBlock::load(
+                    &vb.pp(layer_idx),
+                    mult * nf,
+                    &[(cfg.residual_kernel_size as i64, dilation), (1, 1)],
+                    cfg.activation,
+                    norm,
+                    cfg.causal,
+                    cfg.pad_mode,
+                    cfg.compress as i64,
+                    cfg.true_skip,
+                )?);
+                layer_idx += 1;
+            }
+            let downsample = StreamableConv1d::load(
+                &vb.pp(layer_idx + 1),
+                mult * nf,
+                mult * nf * 2,
+                ratio as i64 * 2,
+                ratio as i64,
+                1,
+                1,
+                true,
+                true,
+                norm,
+                cfg.pad_mode,
+            )?;
+            layer_idx += 2;
+            layers.push(EncoderLayer { residuals, downsample });
+            mult *= 2;
+        }
+
+        let final_norm =
+            if cfg.disable_norm_outer_blocks >= n_blocks { None } else { Some(cfg.norm) };
+        let final_conv = StreamableConv1d::load(
+            &vb.pp(layer_idx + 1),
+            mult * nf,
+            cfg.dimension as i64,
+            cfg.last_kernel_size as i64,
+            1,
+            1,
+            1,
+            true,
+            cfg.causal,
+            final_norm,
+            cfg.pad_mode,
+        )?;
+
+        Ok(Self { init_conv, activation: cfg.activation, layers, final_conv })
+    }
+
+    pub fn forward(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let mut xs = self.init_conv.forward(xs)?;
+        for layer in &self.layers {
+            for residual in &layer.residuals {
+                xs = residual.forward(&xs)?;
+            }
+            xs = self.activation.apply(&xs)?;
+            xs = layer.downsample.forward(&xs)?;
+        }
+        xs = self.activation.apply(&xs)?;
+        self.final_conv.forward(&xs)
+    }
+}
+
+struct DecoderLayer {
+    upsample: StreamableConvTranspose1d,
+    residuals: Vec<SeaNetResnetBlock>,
+}
+
+pub struct SeaNetDecoder {
+    init_conv: StreamableConv1d,
+    activation: Activation,
+    layers: Vec<DecoderLayer>,
+    final_conv: StreamableConv1d,
+    final_activation: Option<Activation>,
+}
+
+impl SeaNetDecoder {
+    pub fn load(vb: &Vb, cfg: &Config) -> Result<Self> {
+        if cfg.lstm.unwrap_or(0) > 0 {
+            return Err(err("seanet lstm is not supported"));
+        }
+        let n_blocks = 2 + cfg.ratios.len();
+        let nf = cfg.n_filters as i64;
+        let mut mult = 1i64 << cfg.ratios.len();
+        let init_norm =
+            if cfg.disable_norm_outer_blocks == n_blocks { None } else { Some(cfg.norm) };
+        let mut layer_idx = 0i64;
+        let vb = vb.pp("model");
+        let init_conv = StreamableConv1d::load(
+            &vb.pp(layer_idx),
+            cfg.dimension as i64,
+            mult * nf,
+            cfg.kernel_size as i64,
+            1,
+            1,
+            1,
+            true,
+            cfg.causal,
+            init_norm,
+            cfg.pad_mode,
+        )?;
+        layer_idx += 1;
+
+        let mut layers = Vec::with_capacity(cfg.ratios.len());
+        for (i, &ratio) in cfg.ratios.iter().enumerate() {
+            let norm = if cfg.disable_norm_outer_blocks + i + 1 >= n_blocks {
+                None
+            } else {
+                Some(cfg.norm)
+            };
+            let upsample = StreamableConvTranspose1d::load(
+                &vb.pp(layer_idx + 1),
+                mult * nf,
+                mult * nf / 2,
+                ratio as i64 * 2,
+                ratio as i64,
+                1,
+                true,
+                true,
+                norm,
+            )?;
+            layer_idx += 2;
+            let mut residuals = Vec::with_capacity(cfg.n_residual_layers);
+            for j in 0..cfg.n_residual_layers {
+                let dilation = (cfg.dilation_base as i64).pow(j as u32);
+                residuals.push(SeaNetResnetBlock::load(
+                    &vb.pp(layer_idx),
+                    mult * nf / 2,
+                    &[(cfg.residual_kernel_size as i64, dilation), (1, 1)],
+                    cfg.activation,
+                    norm,
+                    cfg.causal,
+                    cfg.pad_mode,
+                    cfg.compress as i64,
+                    cfg.true_skip,
+                )?);
+                layer_idx += 1;
+            }
+            layers.push(DecoderLayer { upsample, residuals });
+            mult /= 2;
+        }
+
+        let final_norm = if cfg.disable_norm_outer_blocks >= 1 { None } else { Some(cfg.norm) };
+        let final_conv = StreamableConv1d::load(
+            &vb.pp(layer_idx + 1),
+            nf,
+            cfg.channels as i64,
+            cfg.last_kernel_size as i64,
+            1,
+            1,
+            1,
+            true,
+            cfg.causal,
+            final_norm,
+            cfg.pad_mode,
+        )?;
+
+        Ok(Self {
+            init_conv,
+            activation: cfg.activation,
+            layers,
+            final_conv,
+            final_activation: cfg.final_activation,
+        })
+    }
+
+    pub fn forward(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let mut xs = self.init_conv.forward(xs)?;
+        for layer in &self.layers {
+            xs = self.activation.apply(&xs)?;
+            xs = layer.upsample.forward(&xs)?;
+            for residual in &layer.residuals {
+                xs = residual.forward(&xs)?;
+            }
+        }
+        xs = self.activation.apply(&xs)?;
+        xs = self.final_conv.forward(&xs)?;
+        if let Some(act) = &self.final_activation {
+            xs = act.apply(&xs)?;
+        }
+        Ok(xs)
+    }
+}
+
+fn err(msg: &str) -> crate::Error {
+    crate::Error::Xla(xla::Error::XlaError { msg: msg.to_string(), backtrace: String::new() })
+}

--- a/xla-moshi/src/seanet.rs
+++ b/xla-moshi/src/seanet.rs
@@ -169,8 +169,7 @@ impl SeaNetEncoder {
 
         let mut layers = Vec::with_capacity(cfg.ratios.len());
         for (i, &ratio) in cfg.ratios.iter().rev().enumerate() {
-            let norm =
-                if cfg.disable_norm_outer_blocks >= i + 2 { None } else { Some(cfg.norm) };
+            let norm = if cfg.disable_norm_outer_blocks >= i + 2 { None } else { Some(cfg.norm) };
             let mut residuals = Vec::with_capacity(cfg.n_residual_layers);
             for j in 0..cfg.n_residual_layers {
                 let dilation = (cfg.dilation_base as i64).pow(j as u32);

--- a/xla-moshi/src/transformer.rs
+++ b/xla-moshi/src/transformer.rs
@@ -1,0 +1,362 @@
+//! The Mimi transformer, ported from `xn-moshi` and run over the whole sequence
+//! at once. Only causal + norm-first + `kv_repeat = 1` + rope is supported,
+//! which is what the Mimi configs use.
+use crate::{Result, Vb};
+use xla::{XlaBuilder, XlaOp};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PositionalEmbedding {
+    Rope,
+    Sin,
+    None,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Config {
+    pub d_model: usize,
+    pub num_heads: usize,
+    pub num_layers: usize,
+    pub causal: bool,
+    pub norm_first: bool,
+    pub bias_ff: bool,
+    pub bias_attn: bool,
+    pub layer_scale: Option<f64>,
+    pub positional_embedding: PositionalEmbedding,
+    pub use_conv_block: bool,
+    pub context: usize,
+    pub max_period: f64,
+    pub kv_repeat: usize,
+    pub dim_feedforward: usize,
+    pub conv_layout: bool,
+}
+
+struct Linear {
+    weight: XlaOp,
+    bias: Option<XlaOp>,
+}
+
+impl Linear {
+    fn load(vb: &Vb, in_d: i64, out_d: i64, bias: bool) -> Result<Self> {
+        let weight = vb.var("weight", &[out_d, in_d])?;
+        let bias = if bias { Some(vb.var("bias", &[out_d])?) } else { None };
+        Ok(Self { weight, bias })
+    }
+
+    fn from_weight(weight: XlaOp, bias: Option<XlaOp>) -> Self {
+        Self { weight, bias }
+    }
+
+    fn forward(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let rank = xs.rank()? as i64;
+        let ys = xs.dot_general(&self.weight, &[rank - 1], &[1], &[], &[])?;
+        match &self.bias {
+            None => Ok(ys),
+            Some(b) => {
+                let dims = ys.dims()?;
+                let dims: Vec<i64> = dims.iter().map(|d| *d as i64).collect();
+                let b = b.broadcast_in_dim(&dims, &[rank - 1])?;
+                Ok(ys.add_(&b)?)
+            }
+        }
+    }
+}
+
+struct LayerScale {
+    scale: XlaOp,
+}
+
+impl LayerScale {
+    fn load(vb: &Vb, d_model: i64) -> Result<Self> {
+        Ok(Self { scale: vb.var("scale", &[d_model])? })
+    }
+
+    fn forward(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let d = self.scale.dims()?[0] as i64;
+        let scale = self.scale.reshape(&[1, 1, d])?;
+        Ok(xs.mul_(&scale)?)
+    }
+}
+
+struct LayerNorm {
+    weight: XlaOp,
+    bias: XlaOp,
+}
+
+impl LayerNorm {
+    fn load(vb: &Vb, d_model: i64) -> Result<Self> {
+        Ok(Self { weight: vb.var("weight", &[d_model])?, bias: vb.var("bias", &[d_model])? })
+    }
+
+    fn forward(&self, xs: &XlaOp) -> Result<XlaOp> {
+        // xla's `layer_norm` multiplies/adds scale and bias without rank
+        // broadcasting, so reshape them to `[1, 1, d]` to match `[b, t, d]`.
+        let d = self.weight.dims()?[0] as i64;
+        let weight = self.weight.reshape(&[1, 1, d])?;
+        let bias = self.bias.reshape(&[1, 1, d])?;
+        Ok(xs.layer_norm(-1, &weight, &bias)?)
+    }
+}
+
+/// Precompute the interleaved-rope cos/sin tables for positions `0..t`, shaped
+/// `[1, 1, t, head_dim / 2]` so they broadcast over batch and heads.
+fn rope_tables(
+    builder: &XlaBuilder,
+    t: i64,
+    head_dim: i64,
+    max_period: f32,
+) -> Result<(XlaOp, XlaOp)> {
+    let half = (head_dim / 2) as usize;
+    let mut cos = Vec::with_capacity(t as usize * half);
+    let mut sin = Vec::with_capacity(t as usize * half);
+    for pos in 0..t {
+        for f in 0..half {
+            let inv_freq = 1.0 / max_period.powf(f as f32 / half as f32);
+            let freq = pos as f32 * inv_freq;
+            cos.push(freq.cos());
+            sin.push(freq.sin());
+        }
+    }
+    let shape = [1, 1, t, half as i64];
+    let cos = builder.constant_r1(&cos)?.reshape(&shape)?;
+    let sin = builder.constant_r1(&sin)?.reshape(&shape)?;
+    Ok((cos, sin))
+}
+
+/// Interleaved rope: rotates adjacent pairs `(x[2f], x[2f+1])`. `x` is
+/// `[b, h, t, d]`, cos/sin are `[1, 1, t, d/2]`.
+fn apply_rotary_emb(x: &XlaOp, cos: &XlaOp, sin: &XlaOp) -> Result<XlaOp> {
+    let dims = x.dims()?;
+    let (b, h, t, d) = (dims[0] as i64, dims[1] as i64, dims[2] as i64, dims[3] as i64);
+    let half = d / 2;
+    let x = x.reshape(&[b, h, t, half, 2])?;
+    let x0 = x.slice_in_dim1(0, 1, 4)?.reshape(&[b, h, t, half])?;
+    let x1 = x.slice_in_dim1(1, 2, 4)?.reshape(&[b, h, t, half])?;
+    let cos = cos.broadcast_in_dim(&[b, h, t, half], &[0, 1, 2, 3])?;
+    let sin = sin.broadcast_in_dim(&[b, h, t, half], &[0, 1, 2, 3])?;
+    let o0 = x0.mul_(&cos)?.sub_(&x1.mul_(&sin)?)?;
+    let o1 = x0.mul_(&sin)?.add_(&x1.mul_(&cos)?)?;
+    let o0 = o0.reshape(&[b, h, t, half, 1])?;
+    let o1 = o1.reshape(&[b, h, t, half, 1])?;
+    Ok(o0.concat_in_dim(&[o1], 4)?.reshape(&[b, h, t, d])?)
+}
+
+/// Banded causal mask `[1, 1, t, t]`: query `i` attends to key `j` iff
+/// `j <= i && i - j <= context` (matches `get_mask_abs` in the reference).
+fn attn_mask(builder: &XlaBuilder, t: i64, context: i64) -> Result<XlaOp> {
+    let mut m = Vec::with_capacity((t * t) as usize);
+    for i in 0..t {
+        for j in 0..t {
+            let valid = j <= i && (i - j) <= context;
+            m.push(if valid { 0f32 } else { f32::NEG_INFINITY });
+        }
+    }
+    Ok(builder.constant_r1(&m)?.reshape(&[1, 1, t, t])?)
+}
+
+struct MultiheadAttention {
+    in_proj: Linear,
+    out_proj: Linear,
+    num_heads: i64,
+    head_dim: i64,
+}
+
+impl MultiheadAttention {
+    fn load(vb: &Vb, cfg: &Config) -> Result<Self> {
+        let d_model = cfg.d_model as i64;
+        let num_heads = cfg.num_heads as i64;
+        let head_dim = d_model / num_heads;
+        let num_kv = num_heads / cfg.kv_repeat as i64;
+        let out_dim = d_model + 2 * num_kv * head_dim;
+        let vb_attn = vb.pp("self_attn");
+        let in_proj_weight = vb_attn.var("in_proj_weight", &[out_dim, d_model])?;
+        let in_proj_bias =
+            if cfg.bias_attn { Some(vb_attn.var("in_proj_bias", &[out_dim])?) } else { None };
+        let in_proj = Linear::from_weight(in_proj_weight, in_proj_bias);
+        let out_proj = Linear::load(&vb_attn.pp("out_proj"), d_model, d_model, cfg.bias_attn)?;
+        Ok(Self { in_proj, out_proj, num_heads, head_dim })
+    }
+
+    fn forward(&self, xs: &XlaOp, cos: &XlaOp, sin: &XlaOp, mask: &XlaOp) -> Result<XlaOp> {
+        let dims = xs.dims()?;
+        let (b, t) = (dims[0] as i64, dims[1] as i64);
+        let (h, hd) = (self.num_heads, self.head_dim);
+        let d_model = h * hd;
+
+        let qkv = self.in_proj.forward(xs)?;
+        let split = |start: i64| -> Result<XlaOp> {
+            let s = qkv.slice_in_dim1(start, start + d_model, 2)?;
+            Ok(s.reshape(&[b, t, h, hd])?.transpose(&[0, 2, 1, 3])?)
+        };
+        let q = split(0)?;
+        let k = split(d_model)?;
+        let v = split(2 * d_model)?;
+
+        let q = apply_rotary_emb(&q, cos, sin)?;
+        let k = apply_rotary_emb(&k, cos, sin)?;
+
+        // attn = softmax(q @ k^T * scale + mask) @ v
+        let scale = xs.builder().c0(1f32 / (hd as f32).sqrt())?;
+        let attn = q.dot_general(&k, &[3], &[3], &[0, 1], &[0, 1])?; // [b, h, t, t]
+        let attn = attn.mul_(&scale)?;
+        let mask = mask.broadcast_in_dim(&[b, h, t, t], &[0, 1, 2, 3])?;
+        let attn = attn.add_(&mask)?;
+        let attn = attn.softmax(-1)?;
+        let out = attn.dot_general(&v, &[3], &[2], &[0, 1], &[0, 1])?; // [b, h, t, hd]
+        let out = out.transpose(&[0, 2, 1, 3])?.reshape(&[b, t, d_model])?;
+        self.out_proj.forward(&out)
+    }
+}
+
+struct Mlp {
+    linear1: Linear,
+    linear2: Linear,
+}
+
+impl Mlp {
+    fn load(vb: &Vb, cfg: &Config) -> Result<Self> {
+        let d_model = cfg.d_model as i64;
+        let ff = cfg.dim_feedforward as i64;
+        let linear1 = Linear::load(&vb.pp("linear1"), d_model, ff, cfg.bias_ff)?;
+        let linear2 = Linear::load(&vb.pp("linear2"), ff, d_model, cfg.bias_ff)?;
+        Ok(Self { linear1, linear2 })
+    }
+
+    fn forward(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let xs = self.linear1.forward(xs)?.gelu_erf()?;
+        self.linear2.forward(&xs)
+    }
+}
+
+struct TransformerLayer {
+    self_attn: MultiheadAttention,
+    mlp: Mlp,
+    norm1: LayerNorm,
+    norm2: LayerNorm,
+    layer_scale_1: Option<LayerScale>,
+    layer_scale_2: Option<LayerScale>,
+}
+
+impl TransformerLayer {
+    fn load(vb: &Vb, cfg: &Config) -> Result<Self> {
+        let d_model = cfg.d_model as i64;
+        let self_attn = MultiheadAttention::load(vb, cfg)?;
+        let mlp = Mlp::load(vb, cfg)?;
+        let norm1 = LayerNorm::load(&vb.pp("norm1"), d_model)?;
+        let norm2 = LayerNorm::load(&vb.pp("norm2"), d_model)?;
+        let (layer_scale_1, layer_scale_2) = if cfg.layer_scale.is_some() {
+            (
+                Some(LayerScale::load(&vb.pp("layer_scale_1"), d_model)?),
+                Some(LayerScale::load(&vb.pp("layer_scale_2"), d_model)?),
+            )
+        } else {
+            (None, None)
+        };
+        Ok(Self { self_attn, mlp, norm1, norm2, layer_scale_1, layer_scale_2 })
+    }
+
+    fn forward(&self, xs: &XlaOp, cos: &XlaOp, sin: &XlaOp, mask: &XlaOp) -> Result<XlaOp> {
+        let norm1 = self.norm1.forward(xs)?;
+        let mut attn = self.self_attn.forward(&norm1, cos, sin, mask)?;
+        if let Some(ls) = &self.layer_scale_1 {
+            attn = ls.forward(&attn)?;
+        }
+        let xs = xs.add_(&attn)?;
+        let norm2 = self.norm2.forward(&xs)?;
+        let mut mlp = self.mlp.forward(&norm2)?;
+        if let Some(ls) = &self.layer_scale_2 {
+            mlp = ls.forward(&mlp)?;
+        }
+        Ok(xs.add_(&mlp)?)
+    }
+}
+
+struct Transformer {
+    layers: Vec<TransformerLayer>,
+    head_dim: i64,
+    max_period: f32,
+    context: i64,
+}
+
+impl Transformer {
+    fn load(vb: &Vb, cfg: &Config) -> Result<Self> {
+        if !cfg.causal || !cfg.norm_first || cfg.kv_repeat != 1 {
+            return Err(err("only causal norm_first kv_repeat=1 transformers are supported"));
+        }
+        if cfg.positional_embedding != PositionalEmbedding::Rope {
+            return Err(err("only rope positional embedding is supported"));
+        }
+        let vb_layers = vb.pp("layers");
+        let mut layers = Vec::with_capacity(cfg.num_layers);
+        for i in 0..cfg.num_layers {
+            layers.push(TransformerLayer::load(&vb_layers.pp(i), cfg)?);
+        }
+        Ok(Self {
+            layers,
+            head_dim: (cfg.d_model / cfg.num_heads) as i64,
+            max_period: cfg.max_period as f32,
+            context: cfg.context as i64,
+        })
+    }
+
+    /// `xs`: `[b, t, d_model]` -> `[b, t, d_model]`.
+    fn forward(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let t = xs.dims()?[1] as i64;
+        let builder = xs.builder();
+        let (cos, sin) = rope_tables(builder, t, self.head_dim, self.max_period)?;
+        let mask = attn_mask(builder, t, self.context)?;
+        let mut xs = xs.clone();
+        for layer in &self.layers {
+            xs = layer.forward(&xs, &cos, &sin, &mask)?;
+        }
+        Ok(xs)
+    }
+}
+
+pub struct ProjectedTransformer {
+    input_proj: Option<Linear>,
+    output_proj: Option<Linear>,
+    transformer: Transformer,
+    conv_layout: bool,
+}
+
+impl ProjectedTransformer {
+    pub fn load(vb: &Vb, input_dim: i64, cfg: &Config) -> Result<Self> {
+        let d_model = cfg.d_model as i64;
+        let input_proj = if input_dim != d_model {
+            Some(Linear::load(&vb.pp("input_proj"), input_dim, d_model, false)?)
+        } else {
+            None
+        };
+        let output_proj = if input_dim != d_model {
+            Some(Linear::load(&vb.pp("output_proj").pp(0), d_model, input_dim, false)?)
+        } else {
+            None
+        };
+        let transformer = Transformer::load(&vb.pp("transformer"), cfg)?;
+        Ok(Self { input_proj, output_proj, transformer, conv_layout: cfg.conv_layout })
+    }
+
+    /// `xs`: `[b, c, t]` (conv layout) -> `[b, c, t]`.
+    pub fn forward(&self, xs: &XlaOp) -> Result<XlaOp> {
+        let xs = if self.conv_layout { xs.swap_dims(1, 2)? } else { xs.clone() };
+        let xs = match &self.input_proj {
+            Some(p) => p.forward(&xs)?,
+            None => xs,
+        };
+        let xs = self.transformer.forward(&xs)?;
+        let xs = match &self.output_proj {
+            Some(p) => p.forward(&xs)?,
+            None => xs,
+        };
+        if self.conv_layout {
+            Ok(xs.swap_dims(1, 2)?)
+        } else {
+            Ok(xs)
+        }
+    }
+}
+
+fn err(msg: &str) -> crate::Error {
+    crate::Error::Xla(xla::Error::XlaError { msg: msg.to_string(), backtrace: String::new() })
+}

--- a/xla/src/wrappers/xla_op.rs
+++ b/xla/src/wrappers/xla_op.rs
@@ -99,6 +99,7 @@ impl XlaOp {
     unary_op!(cos, c_lib::op_cos);
     unary_op!(sin, c_lib::op_sin);
     unary_op!(tanh, c_lib::op_tanh);
+    unary_op!(erf, c_lib::op_erf);
     unary_op!(real, c_lib::op_real);
     unary_op!(imag, c_lib::op_imag);
     unary_op!(sqrt, c_lib::op_sqrt);
@@ -123,6 +124,16 @@ impl XlaOp {
     /// This computes the element-wise SiLU activation, x.sigmoid(x).
     pub fn silu(&self) -> Result<Self> {
         self * self.logistic()
+    }
+
+    /// Exact GELU activation, `0.5 * x * (1 + erf(x / sqrt(2)))`.
+    pub fn gelu_erf(&self) -> Result<Self> {
+        let b = self.builder();
+        let inv_sqrt2 = b.c0(std::f32::consts::FRAC_1_SQRT_2)?;
+        let erf = self.mul_(&inv_sqrt2)?.erf()?;
+        let one = b.c0(1f32)?;
+        let half = b.c0(0.5f32)?;
+        self.mul_(&erf.add_(&one)?)?.mul_(&half)
     }
 
     /// A node that applies the specified Einstein summation formula to this node.
@@ -460,6 +471,158 @@ impl XlaOp {
             )
         };
         self.wrap(op)
+    }
+
+    /// Low-level general convolution, mapping directly to XLA's `ConvGeneralDilated`.
+    /// `padding` holds the (low, high) padding for each spatial dimension; `window_strides`,
+    /// `lhs_dilation`, `rhs_dilation` and the three `*_spatial` slices all have one entry per
+    /// spatial dimension. `window_reversal` reverses the kernel along the spatial dims (used to
+    /// express transposed convolutions).
+    #[allow(clippy::too_many_arguments)]
+    pub fn conv_general_dilated(
+        &self,
+        rhs: &XlaOp,
+        window_strides: &[i64],
+        padding: &[(i64, i64)],
+        lhs_dilation: &[i64],
+        rhs_dilation: &[i64],
+        input_batch: i64,
+        input_feature: i64,
+        input_spatial: &[i64],
+        output_batch: i64,
+        output_feature: i64,
+        output_spatial: &[i64],
+        kernel_input_feature: i64,
+        kernel_output_feature: i64,
+        kernel_spatial: &[i64],
+        feature_group_count: i64,
+        batch_group_count: i64,
+        window_reversal: bool,
+    ) -> Result<Self> {
+        let low: Vec<i64> = padding.iter().map(|p| p.0).collect();
+        let high: Vec<i64> = padding.iter().map(|p| p.1).collect();
+        let op = unsafe {
+            c_lib::op_conv_general_dilated(
+                self.op,
+                rhs.op,
+                window_strides.as_ptr(),
+                window_strides.len(),
+                low.as_ptr(),
+                high.as_ptr(),
+                padding.len(),
+                lhs_dilation.as_ptr(),
+                lhs_dilation.len(),
+                rhs_dilation.as_ptr(),
+                rhs_dilation.len(),
+                input_spatial.as_ptr(),
+                output_spatial.as_ptr(),
+                kernel_spatial.as_ptr(),
+                input_spatial.len(),
+                input_batch,
+                input_feature,
+                output_batch,
+                output_feature,
+                kernel_input_feature,
+                kernel_output_feature,
+                feature_group_count,
+                batch_group_count,
+                window_reversal,
+            )
+        };
+        self.wrap(op)
+    }
+
+    /// 1D convolution. `self` has shape `[batch, c_in, len]`, `kernel` has shape
+    /// `[c_out, c_in / groups, k]`, and the result is `[batch, c_out, len_out]`.
+    pub fn conv1d(
+        &self,
+        kernel: &XlaOp,
+        stride: i64,
+        padding: i64,
+        dilation: i64,
+        groups: i64,
+    ) -> Result<Self> {
+        self.conv_general_dilated(
+            kernel,
+            &[stride],
+            &[(padding, padding)],
+            &[1],
+            &[dilation],
+            0,
+            1,
+            &[2],
+            0,
+            1,
+            &[2],
+            1,
+            0,
+            &[2],
+            groups,
+            1,
+            false,
+        )
+    }
+
+    /// Reverse the operand along the given dimensions.
+    pub fn rev(&self, dims: &[i64]) -> Result<Self> {
+        let op = unsafe { c_lib::op_rev(self.op, dims.as_ptr(), dims.len()) };
+        self.wrap(op)
+    }
+
+    /// 1D transposed convolution. `self` has shape `[batch, c_in, len]`, `kernel` uses the
+    /// PyTorch layout `[c_in, c_out / groups, k]`, and the result is `[batch, c_out, len_out]`
+    /// with `len_out = (len - 1) * stride - 2 * padding + dilation * (k - 1) + output_padding + 1`.
+    pub fn conv_transpose1d(
+        &self,
+        kernel: &XlaOp,
+        stride: i64,
+        padding: i64,
+        output_padding: i64,
+        dilation: i64,
+        groups: i64,
+    ) -> Result<Self> {
+        let kd = kernel.dims()?;
+        if kd.len() != 3 {
+            return Err(Error::UnexpectedNumberOfDims {
+                expected: 3,
+                got: kd.len(),
+                dims: kd.iter().map(|d| *d as i64).collect(),
+            });
+        }
+        let (c_in, c_out_g, k) = (kd[0] as i64, kd[1] as i64, kd[2] as i64);
+        let c_out = c_out_g * groups;
+        let c_in_g = c_in / groups;
+        // Rearrange the PyTorch transposed-conv weight [c_in, c_out/groups, k] into the XLA
+        // grouped-conv layout [c_out, c_in/groups, k] and reverse it along the spatial dim.
+        // We reverse the kernel explicitly (rather than relying on the convolution's
+        // `window_reversal` flag) because XLA-GPU mishandles window reversal combined with a
+        // feature group count, giving wrong results for grouped/depthwise transposed convs.
+        let kernel = kernel
+            .reshape(&[groups, c_in_g, c_out_g, k])?
+            .transpose(&[0, 2, 1, 3])?
+            .reshape(&[c_out, c_in_g, k])?
+            .rev(&[2])?;
+        let pad_low = dilation * (k - 1) - padding;
+        let pad_high = dilation * (k - 1) - padding + output_padding;
+        self.conv_general_dilated(
+            &kernel,
+            &[1],
+            &[(pad_low, pad_high)],
+            &[stride],
+            &[dilation],
+            0,
+            1,
+            &[2],
+            0,
+            1,
+            &[2],
+            1,
+            0,
+            &[2],
+            groups,
+            1,
+            false,
+        )
     }
 
     pub fn gather(

--- a/xla/tests/basic_tests.rs
+++ b/xla/tests/basic_tests.rs
@@ -68,6 +68,109 @@ fn matmul_op() -> Result<()> {
 }
 
 #[test]
+fn conv1d_op() -> Result<()> {
+    let client = xla::PjRtClient::cpu()?;
+
+    // Plain conv1d: input [1, 1, 5], kernel [1, 1, 3] of ones, stride 1.
+    let builder = xla::XlaBuilder::new("test");
+    let x = builder.parameter(0, f32::TY, &[1, 1, 5], "x")?;
+    let w = builder.parameter(1, f32::TY, &[1, 1, 3], "w")?;
+    let exe = x.conv1d(&w, 1, 0, 1, 1)?.build()?.compile(&client)?;
+    let x = xla::Literal::vec1(&[1f32, 2., 3., 4., 5.]).reshape(&[1, 1, 5])?;
+    let w = xla::Literal::vec1(&[1f32, 1., 1.]).reshape(&[1, 1, 3])?;
+    let result = exe.execute::<xla::Literal>(&[x, w])?[0][0].to_literal_sync()?;
+    assert_eq!(result.array_shape()?, xla::ArrayShape::new::<f32>(vec![1, 1, 3]));
+    // Sliding window sums: 1+2+3, 2+3+4, 3+4+5.
+    assert_eq!(result.to_vec::<f32>()?, [6., 9., 12.]);
+
+    // Strided conv1d: stride 2 keeps windows starting at positions 0 and 2.
+    let builder = xla::XlaBuilder::new("test");
+    let x = builder.parameter(0, f32::TY, &[1, 1, 5], "x")?;
+    let w = builder.parameter(1, f32::TY, &[1, 1, 3], "w")?;
+    let exe = x.conv1d(&w, 2, 0, 1, 1)?.build()?.compile(&client)?;
+    let x = xla::Literal::vec1(&[1f32, 2., 3., 4., 5.]).reshape(&[1, 1, 5])?;
+    let w = xla::Literal::vec1(&[1f32, 1., 1.]).reshape(&[1, 1, 3])?;
+    let result = exe.execute::<xla::Literal>(&[x, w])?[0][0].to_literal_sync()?;
+    assert_eq!(result.to_vec::<f32>()?, [6., 12.]);
+
+    // Depthwise conv1d: 2 channels, groups = 2, kernel [2, 1, 2].
+    let builder = xla::XlaBuilder::new("test");
+    let x = builder.parameter(0, f32::TY, &[1, 2, 3], "x")?;
+    let w = builder.parameter(1, f32::TY, &[2, 1, 2], "w")?;
+    let exe = x.conv1d(&w, 1, 0, 1, 2)?.build()?.compile(&client)?;
+    // channel 0: [1, 2, 3], channel 1: [4, 5, 6].
+    let x = xla::Literal::vec1(&[1f32, 2., 3., 4., 5., 6.]).reshape(&[1, 2, 3])?;
+    // channel 0 kernel [1, 1], channel 1 kernel [1, -1].
+    let w = xla::Literal::vec1(&[1f32, 1., 1., -1.]).reshape(&[2, 1, 2])?;
+    let result = exe.execute::<xla::Literal>(&[x, w])?[0][0].to_literal_sync()?;
+    assert_eq!(result.array_shape()?, xla::ArrayShape::new::<f32>(vec![1, 2, 2]));
+    // ch0: 1+2, 2+3 ; ch1: 4-5, 5-6.
+    assert_eq!(result.to_vec::<f32>()?, [3., 5., -1., -1.]);
+    Ok(())
+}
+
+#[test]
+fn conv_transpose1d_op() -> Result<()> {
+    let client = xla::PjRtClient::cpu()?;
+
+    // Transposed conv, stride 2, kernel [1, 1, 2] of ones. Each input value is
+    // spread over `stride` output positions: output length (3-1)*2 + 2 = 6.
+    let builder = xla::XlaBuilder::new("test");
+    let x = builder.parameter(0, f32::TY, &[1, 1, 3], "x")?;
+    let w = builder.parameter(1, f32::TY, &[1, 1, 2], "w")?;
+    let exe = x.conv_transpose1d(&w, 2, 0, 0, 1, 1)?.build()?.compile(&client)?;
+    let x = xla::Literal::vec1(&[1f32, 2., 3.]).reshape(&[1, 1, 3])?;
+    let w = xla::Literal::vec1(&[1f32, 1.]).reshape(&[1, 1, 2])?;
+    let result = exe.execute::<xla::Literal>(&[x, w])?[0][0].to_literal_sync()?;
+    assert_eq!(result.array_shape()?, xla::ArrayShape::new::<f32>(vec![1, 1, 6]));
+    assert_eq!(result.to_vec::<f32>()?, [1., 1., 2., 2., 3., 3.]);
+
+    // Depthwise transposed conv: 2 channels, groups = 2, kernel [2, 1, 2].
+    let builder = xla::XlaBuilder::new("test");
+    let x = builder.parameter(0, f32::TY, &[1, 2, 2], "x")?;
+    let w = builder.parameter(1, f32::TY, &[2, 1, 2], "w")?;
+    let exe = x.conv_transpose1d(&w, 2, 0, 0, 1, 2)?.build()?.compile(&client)?;
+    // ch0: [1, 2], ch1: [3, 4].
+    let x = xla::Literal::vec1(&[1f32, 2., 3., 4.]).reshape(&[1, 2, 2])?;
+    // ch0 kernel [1, 1], ch1 kernel [1, 2].
+    let w = xla::Literal::vec1(&[1f32, 1., 1., 2.]).reshape(&[2, 1, 2])?;
+    let result = exe.execute::<xla::Literal>(&[x, w])?[0][0].to_literal_sync()?;
+    assert_eq!(result.array_shape()?, xla::ArrayShape::new::<f32>(vec![1, 2, 4]));
+    // ch0: 1,1,2,2 ; ch1: 3,6,4,8.
+    assert_eq!(result.to_vec::<f32>()?, [1., 1., 2., 2., 3., 6., 4., 8.]);
+
+    // groups=1, 2 in-channels, 2 out-channels, stride 1, to check the
+    // input/output channel mapping (not just depthwise). weight[i, o, :].
+    let builder = xla::XlaBuilder::new("test");
+    let x = builder.parameter(0, f32::TY, &[1, 2, 2], "x")?;
+    let w = builder.parameter(1, f32::TY, &[2, 2, 2], "w")?;
+    let exe = x.conv_transpose1d(&w, 1, 0, 0, 1, 1)?.build()?.compile(&client)?;
+    // in ch0 = [1, 0] (impulse), in ch1 = [0, 1].
+    let x = xla::Literal::vec1(&[1f32, 0., 0., 1.]).reshape(&[1, 2, 2])?;
+    // w[0,0]=[1,0], w[0,1]=[0,0], w[1,0]=[0,0], w[1,1]=[1,0].
+    let w = xla::Literal::vec1(&[1f32, 0., 0., 0., 0., 0., 1., 0.]).reshape(&[2, 2, 2])?;
+    let result = exe.execute::<xla::Literal>(&[x, w])?[0][0].to_literal_sync()?;
+    assert_eq!(result.array_shape()?, xla::ArrayShape::new::<f32>(vec![1, 2, 3]));
+    // out ch0 gets in ch0 via w[0,0]: [1,0,0]; out ch1 gets in ch1 via w[1,1]: [0,1,0].
+    assert_eq!(result.to_vec::<f32>()?, [1., 0., 0., 0., 1., 0.]);
+
+    // stride 2 with k=4 (overlap-add): each output position receives from two
+    // input elements. input [a, b], weight [w0, w1, w2, w3].
+    let builder = xla::XlaBuilder::new("test");
+    let x = builder.parameter(0, f32::TY, &[1, 1, 2], "x")?;
+    let w = builder.parameter(1, f32::TY, &[1, 1, 4], "w")?;
+    let exe = x.conv_transpose1d(&w, 2, 0, 0, 1, 1)?.build()?.compile(&client)?;
+    let x = xla::Literal::vec1(&[2f32, 3.]).reshape(&[1, 1, 2])?;
+    let w = xla::Literal::vec1(&[1f32, 10., 100., 1000.]).reshape(&[1, 1, 4])?;
+    let result = exe.execute::<xla::Literal>(&[x, w])?[0][0].to_literal_sync()?;
+    assert_eq!(result.array_shape()?, xla::ArrayShape::new::<f32>(vec![1, 1, 6]));
+    // a*[1,10,100,1000] at 0.. + b*[1,10,100,1000] at 2..
+    // = [2, 20, 200+3, 2000+30, 300, 3000] = [2, 20, 203, 2030, 300, 3000].
+    assert_eq!(result.to_vec::<f32>()?, [2., 20., 203., 2030., 300., 3000.]);
+    Ok(())
+}
+
+#[test]
 fn pad_op() -> Result<()> {
     let client = xla::PjRtClient::cpu()?;
 

--- a/xla/xla_rs/xla_rs.cc
+++ b/xla/xla_rs/xla_rs.cc
@@ -393,6 +393,46 @@ xla_op op_dot_general(const xla_op lhs, const xla_op rhs, const int64_t *lhs_c,
   END_PROTECT_OP(lhs)
 }
 
+xla_op op_conv_general_dilated(
+    const xla_op lhs, const xla_op rhs, const int64_t *window_strides,
+    size_t n_strides, const int64_t *padding_low, const int64_t *padding_high,
+    size_t n_padding, const int64_t *lhs_dilation, size_t n_lhs_dilation,
+    const int64_t *rhs_dilation, size_t n_rhs_dilation,
+    const int64_t *input_spatial, const int64_t *output_spatial,
+    const int64_t *kernel_spatial, size_t n_spatial, int64_t input_batch,
+    int64_t input_feature, int64_t output_batch, int64_t output_feature,
+    int64_t kernel_input_feature, int64_t kernel_output_feature,
+    int64_t feature_group_count, int64_t batch_group_count,
+    bool window_reversal) {
+  BEGIN_PROTECT_OP
+  ConvolutionDimensionNumbers dnums;
+  dnums.set_input_batch_dimension(input_batch);
+  dnums.set_input_feature_dimension(input_feature);
+  dnums.set_output_batch_dimension(output_batch);
+  dnums.set_output_feature_dimension(output_feature);
+  dnums.set_kernel_input_feature_dimension(kernel_input_feature);
+  dnums.set_kernel_output_feature_dimension(kernel_output_feature);
+  for (size_t i = 0; i < n_spatial; ++i) {
+    dnums.add_input_spatial_dimensions(input_spatial[i]);
+    dnums.add_output_spatial_dimensions(output_spatial[i]);
+    dnums.add_kernel_spatial_dimensions(kernel_spatial[i]);
+  }
+  std::vector<std::pair<int64_t, int64_t>> padding;
+  padding.reserve(n_padding);
+  for (size_t i = 0; i < n_padding; ++i)
+    padding.emplace_back(padding_low[i], padding_high[i]);
+  std::optional<std::vector<bool>> reversal;
+  if (window_reversal)
+    reversal = std::vector<bool>(n_spatial, true);
+  return new XlaOp(ConvGeneralDilated(
+      *lhs, *rhs, absl::Span<const int64_t>(window_strides, n_strides), padding,
+      absl::Span<const int64_t>(lhs_dilation, n_lhs_dilation),
+      absl::Span<const int64_t>(rhs_dilation, n_rhs_dilation), dnums,
+      feature_group_count, batch_group_count, /*precision_config=*/nullptr,
+      /*preferred_element_type=*/std::nullopt, reversal));
+  END_PROTECT_OP(lhs)
+}
+
 xla_op op_eq(const xla_op lhs, const xla_op rhs) {
   BEGIN_PROTECT_OP
   return new XlaOp(Eq(*lhs, *rhs));
@@ -516,6 +556,18 @@ xla_op op_sin(const xla_op arg) {
 xla_op op_tanh(const xla_op arg) {
   BEGIN_PROTECT_OP
   return new XlaOp(Tanh(*arg));
+  END_PROTECT_OP(arg)
+}
+
+xla_op op_erf(const xla_op arg) {
+  BEGIN_PROTECT_OP
+  return new XlaOp(Erf(*arg));
+  END_PROTECT_OP(arg)
+}
+
+xla_op op_rev(const xla_op arg, const int64_t *dims, size_t ndims) {
+  BEGIN_PROTECT_OP
+  return new XlaOp(Rev(*arg, absl::Span<const int64_t>(dims, ndims)));
   END_PROTECT_OP(arg)
 }
 

--- a/xla/xla_rs/xla_rs.h
+++ b/xla/xla_rs/xla_rs.h
@@ -117,6 +117,17 @@ xla_op op_dot(const xla_op, const xla_op);
 xla_op op_dot_general(const xla_op, const xla_op, const int64_t *, size_t,
                       const int64_t *, size_t, const int64_t *, size_t,
                       const int64_t *, size_t);
+xla_op op_conv_general_dilated(
+    const xla_op lhs, const xla_op rhs, const int64_t *window_strides,
+    size_t n_strides, const int64_t *padding_low, const int64_t *padding_high,
+    size_t n_padding, const int64_t *lhs_dilation, size_t n_lhs_dilation,
+    const int64_t *rhs_dilation, size_t n_rhs_dilation,
+    const int64_t *input_spatial, const int64_t *output_spatial,
+    const int64_t *kernel_spatial, size_t n_spatial, int64_t input_batch,
+    int64_t input_feature, int64_t output_batch, int64_t output_feature,
+    int64_t kernel_input_feature, int64_t kernel_output_feature,
+    int64_t feature_group_count, int64_t batch_group_count,
+    bool window_reversal);
 xla_op op_eq(const xla_op, const xla_op);
 xla_op op_ne(const xla_op, const xla_op);
 xla_op op_ge(const xla_op, const xla_op);
@@ -138,6 +149,8 @@ xla_op op_clz(const xla_op);
 xla_op op_cos(const xla_op);
 xla_op op_sin(const xla_op);
 xla_op op_tanh(const xla_op);
+xla_op op_erf(const xla_op);
+xla_op op_rev(const xla_op, const int64_t *, size_t);
 xla_op op_real(const xla_op);
 xla_op op_imag(const xla_op);
 xla_op op_sqrt(const xla_op);


### PR DESCRIPTION
## Summary

Adds a new workspace member, **`xla-moshi`**, implementing the non-streaming (whole-file) forward path of the **Mimi** neural audio codec: SEANet encoder/decoder, the Mimi transformer, and the split residual vector quantizer. The `moshi` example exposes an **AudioToAudio** command that encodes an audio file to discrete codes and decodes them back to a waveform in a single compiled XLA computation.

To support this, convolution primitives were added to the `xla` crate:
- `ConvGeneralDilated`, `Erf` and `Rev` C++ bindings.
- `conv1d` / `conv_transpose1d` / `erf` / `gelu_erf` / `rev` on `XlaOp`, with tests covering plain / strided / depthwise / transposed convolutions.

Transposed convolutions reverse the kernel explicitly rather than using the convolution's window-reversal flag, which XLA-GPU mishandles when combined with a feature group count (it silently produced wrong results for the depthwise upsample).

## Validation

Checked against the `xn-moshi` reference on the same input:
- **Encode codes match exactly** (all codebooks).
- Decoded waveform matches the reference **bit-for-bit on CPU (corr 1.0)** and **GPU (corr 0.9995)**; reconstruction correlates with the input at 0.99.
- Every tensor in the checkpoint is accounted for via `VarBuilder::check_all_used_with_ignore`.

## Notes / limitations

- The whole-file transformer is `O(T^2)`, so this suits short-to-medium clips (a 2 s clip runs at ~45x realtime on GPU). Longer clips would benefit from a chunked/streaming path.
- XLA-GPU prints rematerialization/allocator warnings estimating a high peak-memory during compilation; execution itself is small (~80 MB) and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyiG1LM484d1b8nsGbBoA5