### PR TITLE
Make PJRT handles Send + Sync, add untyped literal download

### DIFF
--- a/xla/src/wrappers/literal.rs
+++ b/xla/src/wrappers/literal.rs
@@ -128,6 +128,22 @@ impl Literal {
         Ok(())
     }
 
+    /// Copy the literal data to a byte slice, regardless of the literal element type. The
+    /// destination has to match the literal size in bytes exactly.
+    pub fn copy_untyped_to(&self, dst: &mut [u8]) -> Result<()> {
+        let size_bytes = self.size_bytes();
+        if dst.len() != size_bytes {
+            Err(Error::BinaryBufferIsTooLarge {
+                element_count: size_bytes,
+                buffer_len: dst.len(),
+            })?
+        }
+        unsafe {
+            c_lib::literal_copy_to(self.0, dst.as_mut_ptr() as *mut libc::c_void, size_bytes)
+        };
+        Ok(())
+    }
+
     /// Copy data from a slice to the literal. This returns an error if the primitive type used
     /// by the literal is not `T` or if number of elements in the slice and the literal are
     /// different.

--- a/xla/src/wrappers/literal.rs
+++ b/xla/src/wrappers/literal.rs
@@ -133,10 +133,7 @@ impl Literal {
     pub fn copy_untyped_to(&self, dst: &mut [u8]) -> Result<()> {
         let size_bytes = self.size_bytes();
         if dst.len() != size_bytes {
-            Err(Error::BinaryBufferIsTooLarge {
-                element_count: size_bytes,
-                buffer_len: dst.len(),
-            })?
+            Err(Error::BinaryBufferIsTooLarge { element_count: size_bytes, buffer_len: dst.len() })?
         }
         unsafe {
             c_lib::literal_copy_to(self.0, dst.as_mut_ptr() as *mut libc::c_void, size_bytes)

--- a/xla/src/wrappers/pjrt_buffer.rs
+++ b/xla/src/wrappers/pjrt_buffer.rs
@@ -8,6 +8,11 @@ pub struct PjRtBuffer {
     pub(super) client: super::PjRtClient,
 }
 
+// SAFETY: PJRT buffers are thread-safe in the C++ API, and the embedded client
+// handle is reference-counted through an `Arc`.
+unsafe impl Send for PjRtBuffer {}
+unsafe impl Sync for PjRtBuffer {}
+
 impl PjRtBuffer {
     /// The client that owns this buffer.
     pub fn client(&self) -> &super::PjRtClient {

--- a/xla/src/wrappers/pjrt_client.rs
+++ b/xla/src/wrappers/pjrt_client.rs
@@ -2,14 +2,20 @@
 use super::{ArrayElement, Literal, PjRtBuffer, PjRtDevice, PjRtLoadedExecutable, XlaComputation};
 use crate::{c_lib, Error, Result};
 use std::marker::PhantomData;
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub(super) struct PjRtClientInternal(pub(self) c_lib::pjrt_client);
+
+// SAFETY: the PJRT C++ API is thread-safe: clients, buffers, and executables
+// can be used concurrently from multiple threads. The internal struct only
+// wraps the raw client pointer.
+unsafe impl Send for PjRtClientInternal {}
+unsafe impl Sync for PjRtClientInternal {}
 
 /// A client represents a device that can be used to run some computations. A computation graph is
 /// compiled in a way that is specific to a device before it can be run.
 #[derive(Clone)]
-pub struct PjRtClient(Rc<PjRtClientInternal>);
+pub struct PjRtClient(Arc<PjRtClientInternal>);
 
 impl PjRtClient {
     /// A CPU client, this can run computations on multiple CPUs at the same time.
@@ -17,7 +23,7 @@ impl PjRtClient {
         let mut ptr: c_lib::pjrt_client = std::ptr::null_mut();
         let status = unsafe { c_lib::pjrt_cpu_client_create(&mut ptr) };
         super::handle_status(status)?;
-        Ok(Self(Rc::new(PjRtClientInternal(ptr))))
+        Ok(Self(Arc::new(PjRtClientInternal(ptr))))
     }
 
     /// A GPU client, the memory requirements are limited by the specified `memory_fraction` and
@@ -28,7 +34,7 @@ impl PjRtClient {
         let status =
             unsafe { c_lib::pjrt_gpu_client_create(&mut ptr, memory_fraction, preallocate) };
         super::handle_status(status)?;
-        Ok(Self(Rc::new(PjRtClientInternal(ptr))))
+        Ok(Self(Arc::new(PjRtClientInternal(ptr))))
     }
 
     /// A TPU client.
@@ -37,7 +43,7 @@ impl PjRtClient {
         let status =
             unsafe { c_lib::pjrt_tpu_client_create(&mut ptr, max_inflight_computations as i32) };
         super::handle_status(status)?;
-        Ok(Self(Rc::new(PjRtClientInternal(ptr))))
+        Ok(Self(Arc::new(PjRtClientInternal(ptr))))
     }
 
     /// A client for the best available platform: try TPU, then GPU, then fall

--- a/xla/src/wrappers/pjrt_loaded_executable.rs
+++ b/xla/src/wrappers/pjrt_loaded_executable.rs
@@ -6,6 +6,12 @@ pub struct PjRtLoadedExecutable {
     pub(super) client: super::PjRtClient,
 }
 
+// SAFETY: PJRT executables are thread-safe in the C++ API (execution can be
+// triggered concurrently), and the embedded client handle is reference-counted
+// through an `Arc`.
+unsafe impl Send for PjRtLoadedExecutable {}
+unsafe impl Sync for PjRtLoadedExecutable {}
+
 impl PjRtLoadedExecutable {
     /// The client that owns this executable.
     pub fn client(&self) -> &super::PjRtClient {


### PR DESCRIPTION
Two small changes needed to drive PJRT from a multi-threaded tensor framework (used by the [xn XLA backend](https://github.com/LaurentMazare/xn)).

### `PjRtClient`: `Rc` → `Arc`, plus `Send`/`Sync`

`PjRtClient` was `Rc`-based and none of the PJRT handles were `Send`/`Sync`, so a client could not be shared across threads. This switches the client to `Arc` and adds `unsafe impl Send + Sync` for `PjRtClientInternal`, `PjRtBuffer`, and `PjRtLoadedExecutable`.

Soundness: the PJRT C++ API is thread-safe — clients, buffers, and executables may be used concurrently, and execution can be triggered from multiple threads. The Rust wrappers hold nothing but the raw handles, and the client handle inside buffers/executables is now reference-counted atomically.

### `Literal::copy_untyped_to`

Copies a literal into a raw byte slice regardless of element type. `copy_raw_to<T: ArrayElement>` requires an `ArrayElement` impl, which the `half` crate's `f16`/`bf16` do not have (only the placeholder `F16`/`Bf16` marker types do), so there was no way to bring f16/bf16 results back to the host. The new method sizes the destination from `size_bytes()` and lets the caller reinterpret.

No existing API changes behaviour; `cargo check -p xla` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LELgDadzc42WwgvdoZLLc8