### PR TITLE
Bump the workspace version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "xla"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "xla-moshi"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "xla-nn"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["xla", "xla-nn", "xla-moshi"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.0"
 authors = ["laurent <laurent.mazare@gmail.com>"]
 edition = "2021"
 description = "Bindings for the XLA C++ library."
@@ -13,8 +13,8 @@ categories = ["science"]
 license = "MIT/Apache-2.0"
 
 [workspace.dependencies]
-xla = { path = "xla", version = "0.3.2" }
-xla-nn = { path = "xla-nn", version = "0.3.2" }
+xla = { path = "xla", version = "0.4.0" }
+xla-nn = { path = "xla-nn", version = "0.4.0" }
 thiserror = "1"
 kaudio = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Bumps the shared workspace version 0.3.2 → **0.4.0**, covering `xla`, `xla-nn` and `xla-moshi` plus the pinned versions of the two path dependencies.

## Why 0.4.0 and not 0.3.3

#25 and #26 added variants to the public `PrimitiveType` and `ElementType` enums, which are **not** `#[non_exhaustive]` — any downstream code matching them exhaustively stops compiling. Under cargo's semver rules that is a breaking change, and for a 0.x crate that means the minor version must move (cargo treats 0.3.x releases as compatible with each other). #25 also promoted `PrimitiveType::element_type` to public API (additive, would have been fine on its own).

## Verified

Full test suite green on this branch (7 suites, including the fp8 and MX tests) against the CPU extension.

## Note for a future release

If enum additivity is expected to continue (more float formats seem likely), marking the two enums `#[non_exhaustive]` in this same breaking release would make *future* variant additions non-breaking. Left out of this PR to keep it a pure version bump — happy to add it here if wanted, since 0.4.0 already takes the compatibility hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgGKBBxXzzgYqtVmog21S8
